### PR TITLE
use ABC sorting order for tree-view items

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/TreeView.js
+++ b/allure-generator/src/main/javascript/components/tree/TreeView.js
@@ -78,7 +78,7 @@ class TreeView extends View {
         return nodes
             .map(item => this.mapNode(statuses, item))
             .filter(item => item.type === 'TestCaseNode' ? statuses[item.status] : item.children.length > 0)
-            .sort((a, b) => a.name < b.name ? 1 : -1);
+            .sort((a, b) => a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1);
     }
 
     mapNode(statuses, node) {

--- a/allure-generator/src/test/javascript/stubs/handlebars-compiler.js
+++ b/allure-generator/src/test/javascript/stubs/handlebars-compiler.js
@@ -5,8 +5,6 @@ const path = require('path');
 const fs = new MemoryFS();
 const file = process.argv[2];
 
-console.log('SETUP HOHOHO');
-
 const compiler = webpack({
     entry: file,
     output: {


### PR DESCRIPTION
Currently it shows all items like
* Z
* Y
* X

This neither not usable or understandable. Before we will implement fully-featured sorting, we need to fix at least in this way.