### PR TITLE
Display duration for tree and overview (fixes #232)

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/tree-leaf.hbs
+++ b/allure-generator/src/main/javascript/components/tree/tree-leaf.hbs
@@ -7,5 +7,8 @@
             {{allure-icon 'flaky'}}
         {{/if}}
         {{name}}
+        <span class="node__stats">
+            {{duration time.duration}}
+        </span>
     </div>
 </a>

--- a/allure-generator/src/main/javascript/helpers/duration.js
+++ b/allure-generator/src/main/javascript/helpers/duration.js
@@ -50,7 +50,7 @@ export default function(timeInt, count) {
             return value + token.suffix;
         });
     if(typeof count !== 'number') {
-        count = 3;
+        count = 2;
     }
     return res.slice(0, count).join(' ');
 }

--- a/allure-generator/src/main/javascript/plugins/summary/SummaryWidgetView.hbs
+++ b/allure-generator/src/main/javascript/plugins/summary/SummaryWidgetView.hbs
@@ -1,18 +1,20 @@
-<h2 class="{{b 'widget' 'title'}}">
-    {{#if isAggregated}}
-        Aggregated report
-        <span class="{{b 'widget' 'subtitle'}}">
-            {{testRunsCount}} test runs
-        </span>
-    {{else}}
-        {{reportName}}
-    {{/if}}
-</h2>
-
 <div class="{{b 'widget' 'flex-line'}}">
-    <div class="{{b 'widget' 'column'}} splash">
-        <div class="{{b 'splash' 'title'}}">{{statistic.total}}</div>
-        <div class="{{b 'splash' 'subtitle'}}">test cases</div>
+    <div class="{{b 'widget' 'column'}}">
+        <h2 class="{{b 'widget' 'title'}}">
+            {{#if isAggregated}}
+                Aggregated report
+                <span class="{{b 'widget' 'subtitle'}}">{{testRunsCount}} test runs</span>
+            {{else}}
+                {{reportName}} {{date time.stop}}
+            {{/if}}
+            <div class="{{b 'widget' 'subtitle'}}">
+                {{time time.start}} - {{time time.stop}} ({{duration time.duration 2}})
+            </div>
+        </h2>
+        <div class="{{b 'summary-widget' 'stats'}} splash">
+            <div class="{{b 'splash' 'title'}}">{{statistic.total}}</div>
+            <div class="{{b 'splash' 'subtitle'}}">test cases</div>
+        </div>
     </div>
     <div class="{{b 'widget' 'column'}} {{b 'summary-widget' 'chart'}}"></div>
 </div>

--- a/allure-generator/src/main/javascript/plugins/summary/styles.css
+++ b/allure-generator/src/main/javascript/plugins/summary/styles.css
@@ -1,6 +1,10 @@
-.summary-widget__chart {
+.summary-widget {
   padding: 1em 0;
-  & > div {
+  &__stats {
+    padding: 2em 0;
+  }
+
+  &__chart > div {
     position: relative;
     padding-top: 50%;
   }

--- a/allure-generator/src/test/javascript/helpers/duration.spec.js
+++ b/allure-generator/src/test/javascript/helpers/duration.spec.js
@@ -21,12 +21,12 @@ describe('duration helper', function () {
     it('should humanize durations', function () {
         expect(duration(10)).toBe('10ms');
         expect(duration(MINUTE)).toBe('1m 00s');
-        expect(duration(66 * SECOND + 1)).toBe('1m 06s 001ms');
+        expect(duration(66 * SECOND + 1)).toBe('1m 06s');
         expect(duration(35 * MINUTE)).toBe('35m 00s');
-        expect(duration(HOUR)).toBe('1h 00m 00s');
-        expect(duration(5 * HOUR + 10 * MINUTE + 5 * SECOND)).toBe('5h 10m 05s');
-        expect(duration(DAY)).toBe('1d 00h 00m');
-        expect(duration(DAY + 5 * MINUTE)).toBe('1d 00h 05m');
+        expect(duration(HOUR)).toBe('1h 00m');
+        expect(duration(5 * HOUR + 10 * MINUTE + 5 * SECOND)).toBe('5h 10m');
+        expect(duration(DAY)).toBe('1d 00h');
+        expect(duration(DAY + 5 * MINUTE)).toBe('1d 00h');
     });
 
     it('should can limit count of signs', function () {


### PR DESCRIPTION
## Overview

<img width="775" alt="screen shot 2017-04-11 at 17 01 36" src="https://cloud.githubusercontent.com/assets/2149631/24913039/9494d918-1ed8-11e7-92f2-bcb92a3e6c79.png">

## Tree

<img width="686" alt="screen shot 2017-04-11 at 17 03 17" src="https://cloud.githubusercontent.com/assets/2149631/24913124/ca4aa5d8-1ed8-11e7-8b14-6394f6a99389.png">

