### PR TITLE
[WIP] Links for groups (fixes #91)

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/xunit/XunitPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/xunit/XunitPlugin.java
@@ -1,8 +1,10 @@
 package io.qameta.allure.xunit;
 
+import io.qameta.allure.entity.GroupLink;
 import io.qameta.allure.entity.LabelName;
 import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.tree.AbstractTreeAggregator;
+import io.qameta.allure.tree.TestGroupNode;
 import io.qameta.allure.tree.TreeGroup;
 
 import java.util.List;
@@ -30,5 +32,14 @@ public class XunitPlugin extends AbstractTreeAggregator {
                 .map(Optional::get)
                 .map(TreeGroup::values)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    protected void afterGroupAdded(final TestGroupNode groupNode, final TestResult result) {
+        result.getGroupLinks().add(new GroupLink()
+                .withGroupType("xunit")
+                .withName(groupNode.getName())
+                .withUrl("/#xUnit/" + groupNode.getUid())
+        );
     }
 }

--- a/allure-generator/src/main/javascript/index.js
+++ b/allure-generator/src/main/javascript/index.js
@@ -28,6 +28,7 @@ import './plugins/testcase-retry';
 import './plugins/testcase-owner';
 import './plugins/testcase-severity';
 import './plugins/testcase-duration';
+import './plugins/testcase-groups';
 import './plugins/testcase-parameters';
 import './plugins/testcase-links';
 

--- a/allure-generator/src/main/javascript/plugins/testcase-groups/GroupsView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testcase-groups/GroupsView.hbs
@@ -1,0 +1,6 @@
+{{#if groupLinks}}
+    <h3 class="pane__section-title">{{t 'testCase.groups.name'}}</h3>
+    {{#each groupLinks}}
+        <a class="link" href="{{url}}">{{name}}</a>
+    {{/each}}
+{{/if}}

--- a/allure-generator/src/main/javascript/plugins/testcase-groups/GroupsView.js
+++ b/allure-generator/src/main/javascript/plugins/testcase-groups/GroupsView.js
@@ -1,0 +1,16 @@
+import {View} from 'backbone.marionette';
+import {className} from '../../decorators';
+import template from './GroupsView.hbs';
+
+@className('pane__section')
+class DurationView extends View {
+    template = template;
+
+    serializeData() {
+        return {
+            groupLinks: this.model.get('groupLinks')
+        };
+    }
+}
+
+export default DurationView;

--- a/allure-generator/src/main/javascript/plugins/testcase-groups/index.js
+++ b/allure-generator/src/main/javascript/plugins/testcase-groups/index.js
@@ -1,0 +1,3 @@
+import GroupsView from './GroupsView';
+
+allure.api.addTestcaseBlock(GroupsView, {position: 'before'});

--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -86,6 +86,9 @@
     "duration": {
       "name": "Duration"
     },
+    "groups": {
+      "name": "Groups"
+    },
     "history": {
       "name": "History",
       "successRate": "Success rate"

--- a/allure-plugin-api/src/main/java/io/qameta/allure/tree/AbstractTreeAggregator.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/tree/AbstractTreeAggregator.java
@@ -77,6 +77,7 @@ public abstract class AbstractTreeAggregator implements Aggregator {
                             });
                     groupNode.updateStatistic(result);
                     groupNode.updateTime(result);
+                    afterGroupAdded(groupNode, result);
                     nextLevelGroups.add(groupNode);
                 }
             }
@@ -102,6 +103,11 @@ public abstract class AbstractTreeAggregator implements Aggregator {
                 .map(TestGroupNode.class::cast)
                 .filter(group -> Objects.equals(groupName, group.getName()))
                 .findAny();
+    }
+
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    protected void afterGroupAdded(final TestGroupNode groupNode, final TestResult result) {
+        //do nothing by default.
     }
 
     protected TreeData postProcess(final TreeData tree) {

--- a/allure-plugin-api/src/main/resources/xsd/allure_report-api.xsd
+++ b/allure-plugin-api/src/main/resources/xsd/allure_report-api.xsd
@@ -43,10 +43,20 @@
                     <xsd:element name="parameters" type="ns:Parameters" minOccurs="0"/>
                     <xsd:element name="links" type="ns:Links" minOccurs="0"/>
 
+                    <xsd:element name="groupLinks" type="ns:GroupLinks" minOccurs="0"/>
                     <xsd:element name="hidden" type="xsd:boolean"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:element name="groupLink" type="ns:GroupLink"/>
+    <xsd:complexType name="GroupLink">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element name="url" type="xsd:string"/>
+            <xsd:element name="groupType" type="xsd:string"/>
+        </xsd:sequence>
     </xsd:complexType>
 
     <xsd:element name="stageResult" type="ns:StageResult"/>
@@ -253,6 +263,12 @@
     <xsd:complexType name="Links">
         <xsd:sequence>
             <xsd:element name="link" type="ns:Link" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GroupLinks">
+        <xsd:sequence>
+            <xsd:element name="groupLink" type="ns:GroupLink" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/allure-plugin-api/src/main/resources/xsd/allure_tree-data.xsd
+++ b/allure-plugin-api/src/main/resources/xsd/allure_tree-data.xsd
@@ -70,6 +70,7 @@
     <xsd:complexType name="TreeWidgetItem">
         <xsd:sequence>
             <xsd:element name="uid" type="xsd:string"/>
+            <xsd:element name="url" type="xsd:string"/>
             <xsd:element name="name" type="xsd:string"/>
             <xsd:element name="statistic" type="api:Statistic"/>
         </xsd:sequence>

--- a/plugins/behaviors-plugin/src/main/java/io/qameta/allure/behaviors/BehaviorsPlugin.java
+++ b/plugins/behaviors-plugin/src/main/java/io/qameta/allure/behaviors/BehaviorsPlugin.java
@@ -3,11 +3,13 @@ package io.qameta.allure.behaviors;
 import io.qameta.allure.Widget;
 import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.LaunchResults;
+import io.qameta.allure.entity.GroupLink;
 import io.qameta.allure.entity.LabelName;
 import io.qameta.allure.entity.Statistic;
 import io.qameta.allure.entity.Status;
 import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.tree.AbstractTreeAggregator;
+import io.qameta.allure.tree.TestGroupNode;
 import io.qameta.allure.tree.TreeGroup;
 import io.qameta.allure.tree.TreeWidgetData;
 import io.qameta.allure.tree.TreeWidgetItem;
@@ -35,6 +37,15 @@ public class BehaviorsPlugin extends AbstractTreeAggregator implements Widget {
 
     private static final String DEFAULT_FEATURE = "Default feature";
     private static final String DEFAULT_STORY = "Default story";
+
+    @Override
+    protected void afterGroupAdded(final TestGroupNode groupNode, final TestResult result) {
+        result.getGroupLinks().add(new GroupLink()
+                .withGroupType("behaviors")
+                .withName(groupNode.getName())
+                .withUrl("/#behaviors/" + groupNode.getUid())
+        );
+    }
 
     @Override
     protected String getFileName() {


### PR DESCRIPTION
This is the basic implementation of links for groups. Checklist:

- [x] Add an ability to add lisks for groups using `AbstractTreeAggregator`
- [x] Links for XUnit
- [ ] Links for BDD
- [ ] Links for Packages
- [ ] Links for Categories
- [ ] Add unit tests
- [ ] Display links on test result page