### PR TITLE
Fix typo in en translation

### DIFF
--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -134,7 +134,7 @@
   },
   "component": {
     "tree": {
-      "filter": "Filter test cases by statues",
+      "filter": "Filter test cases by status",
       "groups": "Toggle groups info",
       "empty": "There are no items",
       "time": {


### PR DESCRIPTION
### Context
`Filter test cases by status` is a correct option in this context according to our native speaker. Not `Filter test cases by statuses`.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] ~~Provide unit tests~~ this is just a typo

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
