### PR TITLE
Add data-tooltips to side navigation icons

### DIFF
--- a/allure-generator/src/main/javascript/components/side-nav/SideNavView.hbs
+++ b/allure-generator/src/main/javascript/components/side-nav/SideNavView.hbs
@@ -5,7 +5,7 @@
 </div>
 <ul class="{{b 'side-nav' 'menu'}}">
     {{#each tabs}}
-        <li class="{{b 'side-nav' 'item'}}">
+        <li class="{{b 'side-nav' 'item'}}" data-tooltip="{{t title}}">
             <a href="#{{tabName}}" class="{{b 'side-nav' 'link' active=active}}">
                 <span class="{{b 'side-nav' 'icon'}} {{icon}}"></span>
                 <div class="{{b 'side-nav' 'text'}}">{{t title}}</div>
@@ -21,7 +21,7 @@
         </button>
     </div>
 
-    <div class="{{b 'side-nav' 'item'}} ">
+    <div class="{{b 'side-nav' 'item'}} " data-tooltip="Expand">
         <div class="{{b 'side-nav' 'collapse'}}">
             <span class="{{b 'side-nav' 'icon'}} fa fa-angle-left"></span>
             <span class="{{b 'side-nav' 'text'}}">{{t 'controls.collapse'}}</span>

--- a/allure-generator/src/main/javascript/components/side-nav/SideNavView.hbs
+++ b/allure-generator/src/main/javascript/components/side-nav/SideNavView.hbs
@@ -21,7 +21,7 @@
         </button>
     </div>
 
-    <div class="{{b 'side-nav' 'item'}} " data-tooltip="Expand">
+    <div class="{{b 'side-nav' 'item'}} " data-tooltip="{{t 'controls.expand'}}">
         <div class="{{b 'side-nav' 'collapse'}}">
             <span class="{{b 'side-nav' 'icon'}} fa fa-angle-left"></span>
             <span class="{{b 'side-nav' 'text'}}">{{t 'controls.collapse'}}</span>

--- a/allure-generator/src/main/javascript/components/side-nav/SideNavView.js
+++ b/allure-generator/src/main/javascript/components/side-nav/SideNavView.js
@@ -1,5 +1,5 @@
 import './styles.css';
-import {className, on, behavior} from '../../decorators';
+import {className, on} from '../../decorators';
 import {findWhere} from 'underscore';
 import {View} from 'backbone.marionette';
 import TooltipView from '../tooltip/TooltipView';
@@ -11,7 +11,6 @@ import template from './SideNavView.hbs';
 import {escapeExpression as escape} from 'handlebars/runtime';
 import router from '../../router';
 
-@behavior('TooltipBehavior', {position: 'right'})
 @className('side-nav')
 class SideNavView extends View {
     template = template;


### PR DESCRIPTION
### Context
In collapsed state this tooltips really help for newbies. New rule: no data-tooltips in Expanded state.

<img width="311" alt="tooltip" src="https://user-images.githubusercontent.com/1412876/27143861-7357f0d6-5138-11e7-9b46-7d5821df480e.png">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] ~~Provide unit tests~~ this is just an icon's tooltip

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
