### PR TITLE
Do not show `empty status details` for passed tests

### DIFF
--- a/allure-generator/src/main/javascript/components/testcase/TestcaseView.hbs
+++ b/allure-generator/src/main/javascript/components/testcase/TestcaseView.hbs
@@ -5,7 +5,7 @@
         <span class="fullname__body">{{fullName}}</span>
 {{/if}}
 </div>
-<h2 class="pane__title">
+<h2 class="pane__title {{#unless statusDetails.message}}pane__title_borderless{{/unless}}">
     {{#if statusDetails.flaky}}
         {{allure-icon 'flaky'}}
     {{/if}}
@@ -16,17 +16,15 @@
     <span class="long-line">{{name}}</span>
 </h2>
 
-<div class="testcase__failure alert message message_status_{{status}}">
+<div class="testcase__failure message message_status_{{status}}">
     {{#if statusDetails.message}}
-        <pre class="alert__code"><code>{{statusDetails.message}}</code></pre>
-    {{else}}
-        {{t 'testCase.status.empty'}}
+        <pre class="alert alert__code"><code>{{statusDetails.message}}</code></pre>
     {{/if}}
     {{#if statusDetails.trace}}
         <div class="testcase__trace-toggle clickable" data-tooltip="{{t 'testCase.status.trace'}}">
             <i class="fa fa-ellipsis-h fa-lg" aria-hidden="true"></i>
         </div>
-        <pre class="alert__code testcase__trace"><code>{{statusDetails.trace}}</code></pre>
+        <pre class="alert alert__code testcase__trace"><code>{{statusDetails.trace}}</code></pre>
     {{/if}}
 </div>
 

--- a/allure-generator/src/main/javascript/components/testcase/styles.css
+++ b/allure-generator/src/main/javascript/components/testcase/styles.css
@@ -5,16 +5,17 @@
   &__trace {
     border-top: 1px solid $border-color;
     padding-top: 10px;
-    margin-top: 10px;
+    margin-top: 0;
     display: none;
     &_visible {
       display: block;
     }
   }
   &__trace-toggle {
-    margin-top: 5px;
+    margin-top: 0;
     text-align: center;
     padding-top: 5px;
+    padding-bottom: 5px;
     color: $text-muted-color;
     &:hover {
       background-color: $hover-color;
@@ -24,7 +25,7 @@
     color: $color-skipped;
   }
   &__failure {
-    padding-bottom: 10px;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
### Context
Text `Empty status details` in passed tests occupies space and distracts attention. Let's skip this block for passed tests.

#### PASSED
Before:
<img width="692" alt="passed-before" src="https://user-images.githubusercontent.com/1412876/27181445-4fe7c5f6-51e0-11e7-8126-a81ab4b5621b.png">
After:
<img width="692" alt="passed-after" src="https://user-images.githubusercontent.com/1412876/27181443-4fe5a8ac-51e0-11e7-842a-80bb6899df5c.png">

#### FAILED
Before:
<img width="691" alt="failed-before" src="https://user-images.githubusercontent.com/1412876/27181442-4fe48d82-51e0-11e7-825a-f4477624ab7c.png">
After:
<img width="691" alt="failed-after" src="https://user-images.githubusercontent.com/1412876/27181441-4fe1668e-51e0-11e7-95cb-626e51a921d5.png">

#### FAILED with StackTrace
Before:
<img width="693" alt="failed-trace-before" src="https://user-images.githubusercontent.com/1412876/27181444-4fe7a0b2-51e0-11e7-86cf-27f31527f7f6.png">
After:
<img width="691" alt="failed-trace-after" src="https://user-images.githubusercontent.com/1412876/27181446-4fe92fc2-51e0-11e7-993a-fb78fe905140.png">

#### PASSED with message
<img width="691" alt="passed-with-message" src="https://user-images.githubusercontent.com/1412876/27185210-51a0942e-51ed-11e7-9882-8e7962cc643b.png">

#### FAILED with NO message
<img width="691" alt="failed-no-message" src="https://user-images.githubusercontent.com/1412876/27185209-51891e0c-51ed-11e7-8bad-0f040afa62d4.png">

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] ~~Provide unit tests~~

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
