### PR TITLE
Do not clash margin values

### DIFF
--- a/allure-generator/src/main/javascript/blocks/widget/styles.scss
+++ b/allure-generator/src/main/javascript/blocks/widget/styles.scss
@@ -61,7 +61,7 @@
 
   &__table {
     border-top: 1px solid $border-color;
-    margin: 0 -$gap-size;
+    margin: 0 (-$gap-size);
     word-break: break-all;
     .table__row:last-child {
       border-bottom: 0;


### PR DESCRIPTION
SASS calculates the expression `0 -$gap-size;`. Parenthes will make it ignored