### PR TITLE
Propose new link type "image"

### DIFF
--- a/allure-generator/src/main/javascript/plugins/testresult-links/LinksView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-links/LinksView.hbs
@@ -8,7 +8,13 @@
         {{#if (eq type "tms")}}
             <span class="fa fa-database"></span>
         {{/if}}
-        <a class="link" href="{{this.url}}" target="_blank">{{name}}</a>
+        <a class="link" href="{{this.url}}" target="_blank">
+            {{#if (eq type "image")}}
+                <img src="{{this.url}}"/>
+            {{else}}
+                {{name}}
+            {{/if}}
+        </a>
     </span>
     {{/each}}
 {{/if}}


### PR DESCRIPTION
This PR is for discussion purposes only.

First of all, thanks for your great tool!
It can build realy awesome reports and it would be even greater if it has ability to attach screenshot located at remote server.

I found that link can be attached to each test case. And there are some custom link types (`issue` and `tms`) that are rendered in special way.

Can we add one more special link type (`image` for example) that would be rendered as clickable image preview?
Something like that: 
<img width="404" alt="screen shot 2017-09-21 at 20 38 37" src="https://user-images.githubusercontent.com/4812960/30711032-1bea0444-9f10-11e7-958f-04748c6b676e.png">



Or maybe you can suggest another way to attach screenshots by link?

It seems to be related with issue #577 

Thank you in advance

