### PR TITLE
Add URI support for attachments

### DIFF
--- a/allure-generator/src/main/javascript/blocks/attachment-row/attachment-row.hbs
+++ b/allure-generator/src/main/javascript/blocks/attachment-row/attachment-row.hbs
@@ -12,8 +12,7 @@
             {{/if}}
         </div>
         <div class="attachment-row__control attachment-row__link">
-            <a class="link" href="data/attachments/{{source}}" target="_blank"
-               data-tooltip="Open attachment in new tab">
+            {{attachment-uri source}}
                 <span class="fa fa-save"></span> {{filesize size}}
             </a>
         </div>

--- a/allure-generator/src/main/javascript/components/attachment/AttachmentView.js
+++ b/allure-generator/src/main/javascript/components/attachment/AttachmentView.js
@@ -17,7 +17,11 @@ class AttachmentView extends View {
         this.fullScreen = !!this.options.fullScreen;
         this.attachment = this.options.attachment;
         this.attachmentInfo = attachmentType(this.attachment.type);
-        this.sourceUrl = 'data/attachments/' + this.attachment.source;
+        if (this.attachment.source.startsWith("http")) {
+          this.sourceUrl = this.attachment.source;
+        } else {
+          this.sourceUrl = 'data/attachments/' + this.attachment.source;
+        }
     }
 
     onRender() {

--- a/allure-generator/src/main/javascript/helpers/attachment-uri.js
+++ b/allure-generator/src/main/javascript/helpers/attachment-uri.js
@@ -1,0 +1,11 @@
+import {SafeString} from 'handlebars/runtime';
+
+export default function attachmentUri(source) {
+  let sourceUri;
+  if (source.startsWith('http')) {
+    sourceUri = source;
+  } else {
+    sourceUri = 'data/attachments/' + source;
+  }
+  return new SafeString(`<a class="link" href="${sourceUri}" target="_blank" data-tooltip="Open attachment in new tab">`);
+}


### PR DESCRIPTION
### Context
Allure attachments were always linked to local files on the report server. With this change you can then add an allure attachment in your test that links to a HTTP/s address of the attachment. For instance this change will allow you to upload your attachments to s3 and attach the link to the report. Our report sizes have begun to grow upwards of 2+ gb and our distributed testing methodology requires us to aggregate all of these files. This solves this by simply allowing each test to upload their attachment to s3 and reduce the size of the report to a couple megabytes.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
