### PR TITLE
(fixes #575 ) Minimizing effect of issue with expanding of previous test result when user clicks on different item

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/TreeView.js
+++ b/allure-generator/src/main/javascript/components/tree/TreeView.js
@@ -92,8 +92,10 @@ class TreeView extends View {
         if (node) {
             const el = this.findElement(node);
             el.toggleClass('node__title_active', active);
-            this.changeState(node.testResult);
-            this.changeState(node.testGroup);
+            el.toggleClass('node__expanded', active);
+            el.parent('.node').toggleClass('node__expanded', active);
+            this.changeState(node.testResult, active);
+            this.changeState(node.testGroup, active);
         }
     }
 
@@ -126,8 +128,6 @@ class TreeView extends View {
     @on('click .node__title')
     onNodeClick(e) {
         const node = this.$(e.currentTarget);
-        const uid = node.data('uid');
-        this.changeState(uid, !this.state.has(uid));
         node.parent().toggleClass('node__expanded');
     }
 


### PR DESCRIPTION
fixes #575 
If user click on a test items, other previously opened test packages also got expanded. 
Fix works if all child nodes of the previously opened item are collapsed. Otherwise previous item will be expanded as a result of https://github.com/allure-framework/allure2/blob/master/allure-generator/src/main/javascript/components/tree/TreeView.js#L115

#### Checklist
- [x] [Sign Allure CLA][cla]

