### PR TITLE
adding indicator for stack trace and english translation implements #501

### DIFF
--- a/allure-generator/src/main/javascript/blocks/status-details/status-details.hbs
+++ b/allure-generator/src/main/javascript/blocks/status-details/status-details.hbs
@@ -2,9 +2,8 @@
     <div class="status-details__content">
         {{#if statusMessage}}
             <div class="{{b 'status-details' 'trace-toggle' status=status}} clickable" data-tooltip="{{t 'testResult.status.trace'}}">
-                <pre class="status-details__message"><code>{{statusMessage}}</code></pre>
+                <pre class="status-details__message"></i><i class="fa fa-info-circle"></i> <b>{{t 'testResult.status.expandTrace'}}</b><br> <code>{{statusMessage}}</code></pre>
             </div>
-
             <pre class="{{b 'status-details' 'trace'}}"><code>{{#if statusTrace}}{{statusTrace}}{{else}}{{t 'testResult.status.empty'}}{{/if}}</code></pre>
         {{/if}}
     </div>

--- a/allure-generator/src/main/javascript/plugins/testresult-duration/DurationView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-duration/DurationView.hbs
@@ -4,4 +4,5 @@
         <span class="fa fa-clock-o"></span>
         {{duration time.duration 2}}
     </span>
+    <span class="fa fa-clipboard" data-copy="{{time time.start}} - {{time time.stop}}"></span>
 {{/if}}

--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -91,7 +91,8 @@
   "testResult": {
     "status": {
       "empty": "Empty status details",
-      "trace": "Show trace"
+      "trace": "Show trace",
+      "expandTrace": "Click to see stack trace"
     },
     "overview": {
       "name": "Overview"


### PR DESCRIPTION
Adding a simple indicator that the statusMessage can be expanded to the user with a new icon + some text.  I am unsure of translations for other language(s) or how we go about implementing those, google translations? so I have added an english translation for now, waiting for your advice there.

![1](https://user-images.githubusercontent.com/17887843/35478165-80559458-03cd-11e8-9878-246d9fb52238.PNG)
