### PR TITLE
Add ability to specify the directory to look for plugins in using `--pluginDirectory`

### DIFF
--- a/allure-commandline/src/main/java/io/qameta/allure/CommandLine.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/CommandLine.java
@@ -137,7 +137,8 @@ public class CommandLine {
                         serveCommand.getResultsOptions().getResultsDirectories(),
                         serveCommand.getHostPortOptions().getHost(),
                         serveCommand.getHostPortOptions().getPort(),
-                        serveCommand.getConfigOptions());
+                        serveCommand.getConfigOptions()
+                );
             case OPEN_COMMAND:
                 return commands.open(
                         openCommand.getReportDirectories().get(0),

--- a/allure-commandline/src/main/java/io/qameta/allure/CommandlineConfig.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/CommandlineConfig.java
@@ -17,4 +17,8 @@ public class CommandlineConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 
     protected List<String> plugins = new ArrayList<>();
+
+    public List<String> getPlugins() {
+        return plugins;
+    }
 }

--- a/allure-commandline/src/main/java/io/qameta/allure/Commands.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/Commands.java
@@ -67,6 +67,13 @@ public class Commands {
         return Optional.empty();
     }
 
+    public Optional<Path> getPluginPath(final ConfigOptions configOptions) {
+        if (Objects.nonNull(configOptions.getPluginDirectory())) {
+            return Optional.of(Paths.get(configOptions.getPluginDirectory()));
+        }
+        return Optional.empty();
+    }
+
     public String getConfigFileName(final String profile) {
         return Objects.isNull(profile)
                 ? "allure.yml"
@@ -174,8 +181,17 @@ public class Commands {
         final DefaultPluginLoader loader = new DefaultPluginLoader();
         final CommandlineConfig commandlineConfig = getConfig(profile);
         final ClassLoader classLoader = getClass().getClassLoader();
+
+        Path pluginPath;
+
+        if (profile.getPluginDirectory() != null) {
+            pluginPath = Paths.get(profile.getPluginDirectory());
+        } else {
+            pluginPath = allureHome.resolve("plugins");
+        }
+
         final List<Plugin> plugins = commandlineConfig.getPlugins().stream()
-                .map(name -> loader.loadPlugin(classLoader, allureHome.resolve("plugins").resolve(name)))
+                .map(name -> loader.loadPlugin(classLoader, pluginPath.resolve(name)))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
@@ -184,6 +200,8 @@ public class Commands {
                 .useDefault()
                 .fromPlugins(plugins)
                 .build();
+
+//
     }
 
     /**

--- a/allure-commandline/src/main/java/io/qameta/allure/option/ConfigOptions.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/option/ConfigOptions.java
@@ -30,6 +30,12 @@ public class ConfigOptions {
     )
     private String configPath;
 
+    @Parameter(
+            names = {"--pluginDirectory"},
+            description = "Allure commandline plugins directory."
+    )
+    private String pluginDirectory;
+
     public String getProfile() {
         return profile;
     }
@@ -40,5 +46,9 @@ public class ConfigOptions {
 
     public String getConfigPath() {
         return configPath;
+    }
+
+    public String getPluginDirectory() {
+        return pluginDirectory;
     }
 }


### PR DESCRIPTION
### Context
In order to add plugins to `allure` in Jenkins, the plugins would have to be added to a directory which may not be available.
This will allow users to maintain a folder of plugins on a job-by-job basis and allow for easier debugging of new plugins especially when paired with Allure Jenkins Plugin.

I have created a PR on `allure-plugin` for Jenkins which will allow for the Allure config to be passed, this will allow us to pass a `--pluginDIrectory` which will need to be added to `allure-plugin` in the future.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
