### PR TITLE
Align close button in modal

### DIFF
--- a/allure-generator/src/main/javascript/components/modal/ModalView.hbs
+++ b/allure-generator/src/main/javascript/components/modal/ModalView.hbs
@@ -2,9 +2,7 @@
     <div class="modal__window">
         <h2 class="{{b cls 'title'}}">
             <span>{{title}}</span>
-            <div class="pane__controls">
-                <span class="modal__close fa fa-close" data-tooltip="Close"></span>
-            </div>
+            <span class="{{b cls 'close'}} fa fa-close" data-tooltip="Close"></span>
         </h2>
         <div class="modal__content"></div>
         <br>

--- a/allure-generator/src/main/javascript/components/modal/styles.scss
+++ b/allure-generator/src/main/javascript/components/modal/styles.scss
@@ -11,6 +11,12 @@
     background-color: rgba(235, 235, 235, 0.7);
     z-index: 1000;
   }
+  &__title {
+    display: flex;
+  }
+  &__close {
+    margin-left: auto;
+  }
   &__window {
     position: absolute;
     width: 90%;


### PR DESCRIPTION
Before

<img width="852" alt="screen shot 2018-06-01 at 2 21 50 pm" src="https://user-images.githubusercontent.com/812240/40841281-3b3d6d70-65aa-11e8-9ccd-90efe1d3fe2b.png">

After 

<img width="818" alt="screen shot 2018-06-01 at 2 40 35 pm" src="https://user-images.githubusercontent.com/812240/40841289-4058e5fa-65aa-11e8-90f1-2b53f44fb620.png">
