### PR TITLE
Add default direction to the document, fix the spinner

### DIFF
--- a/allure-generator/src/main/resources/tpl/index.html.ftl
+++ b/allure-generator/src/main/resources/tpl/index.html.ftl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html dir="ltr">
 <head>
     <meta charset="utf-8">
     <title>Allure Report</title>


### PR DESCRIPTION
If you open current version of report, there will be no spinner, while page is loading.

With this fix, the spinner comes back:

<img width="251" alt="screen shot 2018-06-01 at 3 02 20 pm" src="https://user-images.githubusercontent.com/812240/40842031-d108898c-65ac-11e8-9a05-861a36f5a14b.png">
