### PR TITLE
Add support foe disabled gtests by flagging them as skipped

### DIFF
--- a/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
+++ b/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
@@ -68,6 +68,8 @@ public class JunitXmlPlugin implements Reader {
     private static final String RERUN_ERROR_ELEMENT_NAME = "rerunError";
     private static final String HOSTNAME_ATTRIBUTE_NAME = "hostname";
     private static final String TIMESTAMP_ATTRIBUTE_NAME = "timestamp";
+    private static final String STATUS_ATTRIBUTE_NAME = "status";
+    private static final String SKIPPED_ATTRIBUTE_VALUE = "notrun";
 
     private static final String XML_GLOB = "*.xml";
 
@@ -211,6 +213,12 @@ public class JunitXmlPlugin implements Reader {
         if (testCaseElement.contains(SKIPPED_ELEMENT_NAME)) {
             return Status.SKIPPED;
         }
+
+        if ((testCaseElement.containsAttribute(STATUS_ATTRIBUTE_NAME))
+                && (testCaseElement.getAttribute(STATUS_ATTRIBUTE_NAME).equals(SKIPPED_ATTRIBUTE_VALUE))) {
+            return Status.SKIPPED;
+        }
+
         return Status.PASSED;
     }
 

--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -272,6 +272,23 @@ public class JunitXmlPluginTest {
 
     }
 
+    @Test
+    public void shouldReadSkippedStatus() throws Exception {
+        process(
+                "junitdata/TEST-status-attribute.xml", "TEST-test.SampleTest.xml"
+        );
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(3)).visitTestResult(captor.capture());
+
+        List<TestResult> skipped = filterByStatus(captor.getAllValues(), Status.SKIPPED);
+
+        assertThat(skipped)
+                .describedAs("Should parse skipped elements and status attribute")
+                .hasSize(2);
+
+    }
+
     private void process(String... strings) throws IOException {
         Path resultsDirectory = folder.newFolder().toPath();
         Iterator<String> iterator = Arrays.asList(strings).iterator();

--- a/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-status-attribute.xml
+++ b/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-status-attribute.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+   <testsuite name="JUnitXmlReporter" errors="0" tests="0" failures="0" time="0" timestamp="2013-05-24T10:23:58" />
+   <testsuite name="JUnitXmlReporter.constructor" errors="0" skipped="2" tests="3" failures="0" time="0.06" timestamp="2013-05-24T10:23:58">
+      <testcase classname="JUnitXmlReporter.constructor" name="skipped by element" time="0">
+         <skipped />
+      </testcase>
+      <testcase classname="JUnitXmlReporter.constructor" name="skipped by attribute" status="notrun" time="0" />
+      <testcase classname="JUnitXmlReporter.constructor" name="normal test" time="0.06" />
+   </testsuite>
+</testsuites>


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
Without this fix disabled gtest test are listed as successful test executions instead of skipped tests.
This is due to the fact that gtests indicates disabled tests by setting status to notrun instead of using a skipped element in the junit output. 
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
