### PR TITLE
Use built-in datetime format function

### DIFF
--- a/allure-generator/src/main/javascript/helpers/date.js
+++ b/allure-generator/src/main/javascript/helpers/date.js
@@ -1,4 +1,4 @@
-import pad from 'underscore.string/pad';
+import i18next from '../utils/translation';
 
 export default function (date) {
     if(!date) {
@@ -7,5 +7,5 @@ export default function (date) {
     if(!(date instanceof Date)) {
         date = new Date(date);
     }
-    return [pad(date.getDate(), 2, '0'), pad(date.getMonth() + 1, 2, '0'), date.getFullYear()].join('/');
+    return new Intl.DateTimeFormat(i18next.language).format(date);
 }


### PR DESCRIPTION
Fixes: https://github.com/allure-framework/allure2/issues/801

~~Warning: online edit, did not actually run this locally! 
Is there a way to preview the report after build?~~

Tested in Chrome and Firefox

TODO

* [x] pull the current locale information from `utils/translation.js`