### PR TITLE
Improve XCUI Test Integration.

### DIFF
--- a/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/ResultsUtils.java
+++ b/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/ResultsUtils.java
@@ -76,6 +76,21 @@ public final class ResultsUtils {
                 .setStatus(Status.PASSED);
     }
 
+    public static StepType isTechnicalSteps(final String activityTitle) {
+        if (activityTitle.startsWith("allure.")) {
+            for (StepType stepName : StepType.values()) {
+                if (activityTitle.startsWith(stepName.value())) {
+                    return stepName;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String extractStepValue(final String labelType, final String activityTitle) {
+        return activityTitle.substring(labelType.length() + 1).trim();
+    }
+
     private static String getStepName(final Map<String, Object> props) {
         return (String) props.getOrDefault(STEP_NAME, "Unknown");
     }

--- a/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/StepType.java
+++ b/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/StepType.java
@@ -1,0 +1,22 @@
+package io.qameta.allure.xctest;
+
+/**
+ * Technical steps types.
+ */
+public enum StepType {
+    FEATURE("allure.feature"),
+    ISSUE("allure.issue"),
+    TMS("allure.tms"),
+    STORY("allure.story"),
+    EPIC("allure.epic");
+
+    private final String value;
+
+    StepType(final String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}


### PR DESCRIPTION
Idea was: 
1. Make technical steps in XCUI Tests.
2. Parse steps name in XCUIPlugin.

Code example: 
```
    fileprivate class func addFeature(value: String) {
        return try XCTContext.runActivity(named: "allure.feature: \(value)") { _ in
            // especially left blank
        }
    }
```

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
