### PR TITLE
Fix trx logger parses suite (fixes #749)

### DIFF
--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -185,14 +185,15 @@ public class TrxPlugin implements Reader {
             result.setTestStage(stageResult);
         });
         Optional.ofNullable(tests.get(executionId)).ifPresent(unitTest -> {
-            final String fullName = String.format("%s.%s", unitTest.getFullName(), testName);
+            final String className = unitTest.getClassName();
+            final String fullName = String.format("%s.%s", className, testName);
             result.setParameters(unitTest.getParameters());
             result.setDescription(unitTest.getDescription());
             result.setFullName(fullName);
             result.setHistoryId(fullName);
-            result.addLabelIfNotExists(SUITE, unitTest.getFullName());
-            result.addLabelIfNotExists(TEST_CLASS, unitTest.getFullName());
-            result.addLabelIfNotExists(PACKAGE, unitTest.getFullName());
+            result.addLabelIfNotExists(SUITE, className);
+            result.addLabelIfNotExists(TEST_CLASS, className);
+            result.addLabelIfNotExists(PACKAGE, className);
         });
 
         result.addLabelIfNotExists(RESULT_FORMAT, TRX_RESULTS_FORMAT);

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -114,7 +114,7 @@ public class TrxPlugin implements Reader {
 
     protected UnitTest parseUnitTest(final XmlElement unitTestElement) {
         final String name = unitTestElement.getAttribute(NAME_ATTRIBUTE);
-        final String fullName = unitTestElement.getFirst(TEST_METHOD_ELEMENT)
+        final String className = unitTestElement.getFirst(TEST_METHOD_ELEMENT)
                 .map(testMethod -> testMethod.getAttribute(CLASS_NAME_ATTRIBUTE))
                 .orElse(null);
         final String description = unitTestElement.getFirst(DESCRIPTION_ELEMENT)
@@ -124,7 +124,7 @@ public class TrxPlugin implements Reader {
                 .map(execution -> execution.getAttribute(ID_ATTRIBUTE))
                 .orElse(null);
         final Map<String, String> properties = parseProperties(unitTestElement);
-        return new UnitTest(name, fullName, executionId, description, properties);
+        return new UnitTest(name, className, executionId, description, properties);
     }
 
     private Map<String, String> parseProperties(final XmlElement unitTestElement) {
@@ -185,11 +185,11 @@ public class TrxPlugin implements Reader {
             result.setTestStage(stageResult);
         });
         Optional.ofNullable(tests.get(executionId)).ifPresent(unitTest -> {
-            final String fullNameWithTestName = unitTest.getFullName() + "." + testName;
+            final String fullName = String.format("%s.%s", unitTest.getFullName(), testName);
             result.setParameters(unitTest.getParameters());
             result.setDescription(unitTest.getDescription());
-            result.setFullName(fullNameWithTestName);
-            result.setHistoryId(fullNameWithTestName);
+            result.setFullName(fullName);
+            result.setHistoryId(fullName);
             result.addLabelIfNotExists(SUITE, unitTest.getFullName());
             result.addLabelIfNotExists(TEST_CLASS, unitTest.getFullName());
             result.addLabelIfNotExists(PACKAGE, unitTest.getFullName());

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -35,6 +35,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.qameta.allure.entity.LabelName.RESULT_FORMAT;
+import static io.qameta.allure.entity.LabelName.PACKAGE;
+import static io.qameta.allure.entity.LabelName.SUITE;
+import static io.qameta.allure.entity.LabelName.TEST_CLASS;
 import static java.nio.file.Files.newDirectoryStream;
 
 /**
@@ -57,6 +60,8 @@ public class TrxPlugin implements Reader {
     public static final String TEST_DEFINITIONS_ELEMENT = "TestDefinitions";
     public static final String UNIT_TEST_ELEMENT = "UnitTest";
     public static final String NAME_ATTRIBUTE = "name";
+    public static final String TEST_METHOD_ELEMENT = "TestMethod";
+    public static final String CLASS_NAME_ATTRIBUTE = "className";
     public static final String PROPERTIES_ELEMENT = "Properties";
     public static final String PROPERTY_ATTRIBUTE = "Property";
     public static final String KEY_ELEMENT = "Key";
@@ -109,6 +114,9 @@ public class TrxPlugin implements Reader {
 
     protected UnitTest parseUnitTest(final XmlElement unitTestElement) {
         final String name = unitTestElement.getAttribute(NAME_ATTRIBUTE);
+        final String fullName = unitTestElement.getFirst(TEST_METHOD_ELEMENT)
+                .map(testMethod -> testMethod.getAttribute(CLASS_NAME_ATTRIBUTE))
+                .orElse(null);
         final String description = unitTestElement.getFirst(DESCRIPTION_ELEMENT)
                 .map(XmlElement::getValue)
                 .orElse(null);
@@ -116,7 +124,7 @@ public class TrxPlugin implements Reader {
                 .map(execution -> execution.getAttribute(ID_ATTRIBUTE))
                 .orElse(null);
         final Map<String, String> properties = parseProperties(unitTestElement);
-        return new UnitTest(name, executionId, description, properties);
+        return new UnitTest(name, fullName, executionId, description, properties);
     }
 
     private Map<String, String> parseProperties(final XmlElement unitTestElement) {
@@ -177,8 +185,14 @@ public class TrxPlugin implements Reader {
             result.setTestStage(stageResult);
         });
         Optional.ofNullable(tests.get(executionId)).ifPresent(unitTest -> {
+            final String fullNameWithTestName = unitTest.getFullName() + "." + testName;
             result.setParameters(unitTest.getParameters());
             result.setDescription(unitTest.getDescription());
+            result.setFullName(fullNameWithTestName);
+            result.setHistoryId(fullNameWithTestName);
+            result.addLabelIfNotExists(SUITE, unitTest.getFullName());
+            result.addLabelIfNotExists(TEST_CLASS, unitTest.getFullName());
+            result.addLabelIfNotExists(PACKAGE, unitTest.getFullName());
         });
 
         result.addLabelIfNotExists(RESULT_FORMAT, TRX_RESULTS_FORMAT);

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/UnitTest.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/UnitTest.java
@@ -13,13 +13,15 @@ public class UnitTest {
 
     public static final String PARAMETER_PREFIX = "Parameter:";
     private final String name;
+    private final String fullName;
     private final String executionId;
     private final String description;
     private final Map<String, String> properties;
 
-    public UnitTest(final String name, final String executionId,
+    public UnitTest(final String name, final String fullName, final String executionId,
                     final String description, final Map<String, String> properties) {
         this.name = name;
+        this.fullName = fullName;
         this.executionId = executionId;
         this.description = description;
         this.properties = properties;
@@ -27,6 +29,10 @@ public class UnitTest {
 
     public String getName() {
         return name;
+    }
+
+    public String getFullName() {
+        return fullName;
     }
 
     public String getExecutionId() {

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/UnitTest.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/UnitTest.java
@@ -13,15 +13,15 @@ public class UnitTest {
 
     public static final String PARAMETER_PREFIX = "Parameter:";
     private final String name;
-    private final String fullName;
+    private final String className;
     private final String executionId;
     private final String description;
     private final Map<String, String> properties;
 
-    public UnitTest(final String name, final String fullName, final String executionId,
+    public UnitTest(final String name, final String className, final String executionId,
                     final String description, final Map<String, String> properties) {
         this.name = name;
-        this.fullName = fullName;
+        this.className = className;
         this.executionId = executionId;
         this.description = description;
         this.properties = properties;
@@ -31,8 +31,8 @@ public class UnitTest {
         return name;
     }
 
-    public String getFullName() {
-        return fullName;
+    public String getClassName() {
+        return className;
     }
 
     public String getExecutionId() {

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -90,6 +90,23 @@ public class TrxPluginTest {
                 .containsExactly(tuple("Some message", "Some trace"));
     }
 
+    @Issue("749")
+    @Test
+    public void shouldParseClassNameAsSuite() throws Exception {
+        process(
+                "trxdata/gh-749.trx",
+                "sample.trx"
+        );
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(1)).visitTestResult(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .extracting(result -> result.findOneLabel(LabelName.SUITE))
+                .extracting(Optional::get)
+                .containsOnly("TestClass");
+    }
+	
     @Test
     public void shouldParseStdOutOnFail() throws Exception {
         process(

--- a/plugins/trx-plugin/src/test/resources/trxdata/gh-749.trx
+++ b/plugins/trx-plugin/src/test/resources/trxdata/gh-749.trx
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="d32752e7-f92d-4636-8aa4-3c5c13c81fd7" name="@computerName 2018-10-08 15:34:14" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+    <Times creation="2018-10-08T15:34:14.0933035+02:00" queuing="2018-10-08T15:34:14.0933035+02:00" start="2018-10-08T15:34:12.5177742+02:00" finish="2018-10-08T15:34:17.5631430+02:00" />
+    <TestSettings name="default" id="1809e9e4-7476-4883-b0f9-da4351c5a870">
+        <Deployment runDeploymentRoot="_computerName_2018-10-08_15_34_14" />
+    </TestSettings>
+    <Results>
+        <UnitTestResult executionId="3f66826e-4985-4f0c-8487-fb22efe22dd6" testId="baee4da8-a695-8106-f452-fc8078d9cc22" testName="testMethod" computerName="computerName" duration="00:00:00.1054123" startTime="2018-10-08T15:34:12.7049658+02:00" endTime="2018-10-08T15:34:12.8453595+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3f66826e-4985-4f0c-8487-fb22efe22dd6" />
+    </Results>
+    <TestDefinitions>
+        <UnitTest name="testMethod" storage="C:\tmp\bin\debug\test.dll" id="baee4da8-a695-8106-f452-fc8078d9cc22">
+            <Execution id="3f66826e-4985-4f0c-8487-fb22efe22dd6" />
+            <TestMethod codeBase="C:\tmp\bin\Debug\Test.dll" adapterTypeName="executor://mstestadapter/v2" className="TestClass" name="testMethod" />
+        </UnitTest>
+    </TestDefinitions>
+    <TestEntries>
+        <TestEntry testId="baee4da8-a695-8106-f452-fc8078d9cc22" executionId="3f66826e-4985-4f0c-8487-fb22efe22dd6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    </TestEntries>
+    <TestLists>
+        <TestList name="Ergebnisse nicht in einer Liste" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestList name="Alle geladenen Ergebnisse" id="19431567-8539-422a-85d7-44ee4e166bda" />
+    </TestLists>
+    <ResultSummary outcome="Failed">
+        <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    </ResultSummary>
+</TestRun>


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context

Previously, the trx plugin read only the name of a test. Thereby, each test ended up in an own package/suite. 

Now, the plugin reads the className attribute of the testMethod element in the trx files and stores this name as Suite, TestClass and Package. Furthermore, the className along with the name of the testMethod is used as FullName and HistoryId.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
