### PR TITLE
Fix trx logger parses stdout on fail

### DIFF
--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -171,7 +171,7 @@ public class TrxPlugin implements Reader {
                 final List<String> lines = splitLines(logMessage);
                 final List<Step> steps = lines
                         .stream()
-                        .map(line -> new Step.setName(line))
+                        .map(line -> new Step().setName(line))
                         .collect(Collectors.toList());
                 final StageResult stageResult = new StageResult()
                         .setSteps(steps);

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -166,18 +166,16 @@ public class TrxPlugin implements Reader {
                 .setTime(getTime(startTime, endTime));
         getStatusMessage(unitTestResult).ifPresent(result::setStatusMessage);
         getStatusTrace(unitTestResult).ifPresent(result::setStatusTrace);
-        if (result.getStatus() != Status.PASSED) {
-            getLogMessage(unitTestResult).ifPresent(logMessage -> {
-                final List<String> lines = splitLines(logMessage);
-                final List<Step> steps = lines
-                        .stream()
-                        .map(line -> new Step().setName(line))
-                        .collect(Collectors.toList());
-                final StageResult stageResult = new StageResult()
-                        .setSteps(steps);
-                result.setTestStage(stageResult);
-            });
-        }
+        getLogMessage(unitTestResult).ifPresent(logMessage -> {
+            final List<String> lines = splitLines(logMessage);
+            final List<Step> steps = lines
+                    .stream()
+                    .map(line -> new Step().setName(line))
+                    .collect(Collectors.toList());
+            final StageResult stageResult = new StageResult()
+                    .setSteps(steps);
+            result.setTestStage(stageResult);
+        });
         Optional.ofNullable(tests.get(executionId)).ifPresent(unitTest -> {
             result.setParameters(unitTest.getParameters());
             result.setDescription(unitTest.getDescription());

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -102,8 +102,9 @@ public class TrxPluginTest {
 
         assertThat(captor.getAllValues())
                 .filteredOn(result -> result.getStatus() == Status.FAILED)
-                .filteredOn(result -> result.getStatusTrace().contains("Given I have entered 50 into the calculator"))
-                .filteredOn(result -> result.getStatusTrace().contains("And I have entered -1 into the calculator"))
+                .filteredOn(result -> result.getTestStage().getSteps().size() == 10)
+                .filteredOn(result -> result.getTestStage().getSteps().get(1).getName().contains("Given I have entered 50 into the calculator"))
+                .filteredOn(result -> result.getTestStage().getSteps().get(3).getName().contains("And I have entered -1 into the calculator"))
                 .hasSize(1);
     }
 

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -90,6 +90,23 @@ public class TrxPluginTest {
                 .containsExactly(tuple("Some message", "Some trace"));
     }
 
+    @Test
+    public void shouldParseStdOutOnFail() throws Exception {
+        process(
+                "trxdata/sample.trx",
+                "sample.trx"
+        );
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(4)).visitTestResult(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .filteredOn(result -> result.getStatus() == Status.FAILED)
+                .filteredOn(result -> result.getStatusTrace().contains("Given I have entered 50 into the calculator"))
+                .filteredOn(result -> result.getStatusTrace().contains("And I have entered -1 into the calculator"))
+                .hasSize(1);
+    }
+
     private void process(String... strings) throws IOException {
         Path resultsDirectory = folder.newFolder().toPath();
         Iterator<String> iterator = Arrays.asList(strings).iterator();


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context

Previously, the standard output contained in the trx files was ignored by the trx plugin.

Now, the plugin appends this output to the StatusTrace for failing tests.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
