### PR TITLE
Improve processing of empty history data file

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/history/HistoryTrendPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/history/HistoryTrendPlugin.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -84,11 +85,16 @@ public class HistoryTrendPlugin extends CompositeAggregator implements Reader {
             try (InputStream is = Files.newInputStream(historyFile)) {
                 final ObjectMapper mapper = context.getValue();
                 final JsonNode jsonNode = mapper.readTree(is);
-                final List<HistoryTrendItem> history = getStream(jsonNode)
-                        .map(child -> parseItem(historyFile, mapper, child))
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(Collectors.toList());
+                final List<HistoryTrendItem> history;
+                if (jsonNode != null) {
+                    history = getStream(jsonNode)
+                            .map(child -> parseItem(historyFile, mapper, child))
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .collect(Collectors.toList());
+                } else {
+                    history = Collections.emptyList();
+                }
 
                 visitor.visitExtra(HISTORY_TREND_BLOCK_NAME, history);
             } catch (IOException e) {

--- a/allure-generator/src/test/java/io/qameta/allure/history/HistoryTrendPluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/history/HistoryTrendPluginTest.java
@@ -127,6 +127,27 @@ class HistoryTrendPluginTest {
                 );
     }
 
+    @Test
+    void shouldProcessCorruptedData(@TempDir final Path resultsDirectory) throws Exception {
+        final Path history = Files.createDirectories(resultsDirectory.resolve("history"));
+        Files.createFile(history.resolve("history-trend.json"));
+
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.requireContext(JacksonContext.class))
+                .thenReturn(new JacksonContext());
+
+        final ResultsVisitor visitor = mock(ResultsVisitor.class);
+
+        final HistoryTrendPlugin plugin = new HistoryTrendPlugin();
+        plugin.readResults(configuration, visitor, resultsDirectory);
+
+        final ArgumentCaptor<List<HistoryTrendItem>> captor = ArgumentCaptor.forClass(List.class);
+        verify(visitor, times(1))
+                .visitExtra(eq(HISTORY_TREND_BLOCK_NAME), captor.capture());
+
+        assertThat(captor.getValue()).hasSize(0);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void shouldAggregateForEmptyReport(@TempDir final Path outputDirectory) throws Exception {


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
Sometimes history data file could be empty on our CI server (that happens due to external reasons not related to Allure). When such file is used during report generation, NPE is thrown.


#### Checklist
- [X] [Sign Allure CLA][cla]
- [X] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
