### PR TITLE
Fixes #693 show retries on timeline

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/timeline/TimelinePlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/timeline/TimelinePlugin.java
@@ -49,7 +49,7 @@ public class TimelinePlugin extends CommonJsonAggregator {
         // @formatter:on
 
         launchResults.stream()
-                .map(LaunchResults::getResults)
+                .map(LaunchResults::getAllResults)
                 .flatMap(Collection::stream)
                 .forEach(timeline::add);
         return timeline;


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)
Fixes #693 \ отображение в timeline всех прогонов тестов, включая упавшие и потом заретраенные.

### Context
Current timeline shows only last tries. And if you there were several retries you display gap at timeline.
The reason for this behaviour is that TimelinePlugin filter hidde TestResult after RetryPlugin.
It`s necessary to Suite tab, but unuseless to Timeline Tab.
All results will be displayed if change getAllResults to shows.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
