### PR TITLE
Fix maximize of attachment when test opened from timeline

### DIFF
--- a/allure-generator/src/main/javascript/layouts/testresult/TestResultLayout.js
+++ b/allure-generator/src/main/javascript/layouts/testresult/TestResultLayout.js
@@ -2,6 +2,7 @@ import AppLayout from '../application/AppLayout';
 import TestResultView from '../../components/testresult/TestResultView';
 import {Model} from 'backbone';
 import TestResultModel from '../../data/testresult/TestResultModel';
+import router from '../../router';
 
 export default class TestResultLayout extends AppLayout {
 
@@ -28,6 +29,13 @@ export default class TestResultLayout extends AppLayout {
 
     onRouteUpdate(uid, tabName) {
         this.routeState.set('testResultTab', tabName);
+
+        const attachment = router.getUrlParams().attachment;
+        if (attachment) {
+            this.routeState.set('attachment', attachment);
+        } else {
+            this.routeState.unset('attachment');
+        }
     }
 
     shouldKeepState(uid) {


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
There is an issue in displaying of attachment when test is opened form timeline:
- Go to: https://demo.qameta.io/allure/#timeline
- Click on any test (which contains attachment)
- Click maximize sign on attachment
Actual: nothing happened

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
