### PR TITLE
Fix flaky and newFailed icons aligment issue in Suites view

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/tree-leaf.hbs
+++ b/allure-generator/src/main/javascript/components/tree/tree-leaf.hbs
@@ -7,6 +7,7 @@
         <div class="node__name">
             {{name}}
         </div>
+        <div class="tree__strut">&nbsp</div>
         {{#if flaky}}
         <div class="{{b 'node' 'flaky' shown=flaky}}">
             {{allure-icon 'flaky'}}
@@ -31,7 +32,6 @@
             {{/each}}
         </div>
         {{/if}}
-        <div class="tree__strut">&nbsp</div>
         <div class="node__stats">
             {{~duration time.duration~}}
         </div>


### PR DESCRIPTION
-  Fix flaky and newFailed icons aligment issue in Suites view by reordering `tree__strut` div

![Allure_TreeStrut](https://user-images.githubusercontent.com/24920942/57133881-f0025d00-6dac-11e9-871c-f5b250b921b0.png)

The order is now consistent with the order in tree-group.hbs 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
