### PR TITLE
Fix path to allure-version.txt resource

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/ga/GaPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/ga/GaPlugin.java
@@ -70,6 +70,8 @@ public class GaPlugin implements Aggregator {
     private static final String GA_ENDPOINT = "https://www.google-analytics.com/collect";
     private static final String GA_API_VERSION = "1";
 
+    private static final String ALLURE_VERSION_TXT_PATH = "/allure-version.txt";
+
     @Override
     public void aggregate(final Configuration configuration,
                           final List<LaunchResults> launchesResults,
@@ -152,12 +154,12 @@ public class GaPlugin implements Aggregator {
 
     private static Optional<String> getVersionFromFile() {
         try {
-            return Optional.of(IOUtils.resourceToString("allure-version.txt", StandardCharsets.UTF_8))
+            return Optional.of(IOUtils.resourceToString(ALLURE_VERSION_TXT_PATH, StandardCharsets.UTF_8))
                     .map(String::trim)
                     .filter(v -> !v.isEmpty())
                     .filter(v -> !"#project.version#".equals(v));
         } catch (IOException e) {
-            LOGGER.debug("Could not read allure-version.txt resource", e);
+            LOGGER.debug("Could not read {} resource", ALLURE_VERSION_TXT_PATH, e);
             return Optional.empty();
         }
     }


### PR DESCRIPTION
### Context
The exception is logged by GaPlugin at test report generation:
```java
DEBUG io.qameta.allure.ga.GaPlugin - send analytics
DEBUG io.qameta.allure.ga.GaPlugin - Could not read allure-version.txt resource
java.io.IOException: Resource not found: allure-version.txt
	at org.apache.commons.io.IOUtils.resourceToURL(IOUtils.java:1372)
	at org.apache.commons.io.IOUtils.resourceToString(IOUtils.java:1293)
	at org.apache.commons.io.IOUtils.resourceToString(IOUtils.java:1272)
	at io.qameta.allure.ga.GaPlugin.getVersionFromFile(GaPlugin.java:155)
	at io.qameta.allure.ga.GaPlugin.getAllureVersion(GaPlugin.java:149)
	at io.qameta.allure.ga.GaPlugin.aggregate(GaPlugin.java:83)
	at io.qameta.allure.ReportGenerator.aggregate(ReportGenerator.java:53)
	at io.qameta.allure.ReportGenerator.generate(ReportGenerator.java:70)
	at io.qameta.allure.ReportGenerator.generate(ReportGenerator.java:62)
...
DEBUG io.qameta.allure.ga.GaPlugin - GA done
```

#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
