### PR TITLE
Add automatically taken screenshots by xcode

### DIFF
--- a/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
+++ b/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
@@ -169,7 +169,7 @@ public class XcTestPlugin implements Reader {
                                final Map<String, Object> props,
                                final Step step) {
         final String uuid = props.get("UUID").toString();
-        final Path attachments = directory.resolve("Attachments");
+        final Path attachments = directory.resolve(ATTACHMENTS);
         Stream.of("jpg", "png")
             .map(ext -> attachments.resolve(String.format("Screenshot_%s.%s", uuid, ext)))
             .filter(Files::exists)

--- a/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
+++ b/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
@@ -63,6 +63,7 @@ public class XcTestPlugin implements Reader {
     private static final String SUB_ACTIVITIES = "SubActivities";
     private static final String ACTIVITY_SUMMARIES = "ActivitySummaries";
     private static final String HAS_SCREENSHOT = "HasScreenshotData";
+    private static final String ATTACHMENTS = "Attachments";
 
 
     @Override
@@ -141,10 +142,10 @@ public class XcTestPlugin implements Reader {
             step.setStatus(Status.FAILED);
         }
 
-        if (props.containsKey(HAS_SCREENSHOT)) {
+        if (props.containsKey(HAS_SCREENSHOT) || props.containsKey(ATTACHMENTS)) {
             addAttachment(directory, visitor, props, step);
         }
-
+        
         if (parent instanceof TestResult) {
             ((TestResult) parent).getTestStage().getSteps().add(step);
         }


### PR DESCRIPTION
When run UI tests from Xcode it automatically takes screenshots. In the report `Test-UITests-2019.07.21_19-05-05-+0300.xcresult/` they are in the `Attachments` section (see screenshot below).
With this fix such screenshots will be attached to the Allure report.
![image](https://user-images.githubusercontent.com/42713159/61596946-81e26f00-ac12-11e9-9975-7016e5c6f99c.png)
 
![image](https://user-images.githubusercontent.com/42713159/61596997-38deea80-ac13-11e9-85d9-dc8f7111984e.png)
