### PR TITLE
fixing issue with trx-plugin date

### DIFF
--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -268,7 +268,7 @@ public class TrxPlugin implements Reader {
             return Optional.ofNullable(time)
                     .map(ZonedDateTime::parse)
                     .map(ChronoZonedDateTime::toInstant)
-                    .map(Instant::getEpochSecond);
+                    .map(Instant::toEpochMilli);
         } catch (Exception e) {
             LOGGER.error("Could not parse time {}", time, e);
             return Optional.empty();


### PR DESCRIPTION
-changing getEpochTime to toEpochMilli

### Context

The trx-plugin was converting dates in the report to 1/18/1970 (a few days after the beginning of the Java Epoch). The duration of the test runs were also wrong. This was due to the Java code returning Epoch in seconds and JavaScript expecting it in milliseconds.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
