### PR TITLE
adds JUnit's system-out to report (fixes #744)

### DIFF
--- a/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
+++ b/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
@@ -26,6 +26,7 @@ import io.qameta.allure.datetime.ZonedDateTimeParser;
 import io.qameta.allure.entity.LabelName;
 import io.qameta.allure.entity.StageResult;
 import io.qameta.allure.entity.Status;
+import io.qameta.allure.entity.Step;
 import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.entity.Time;
 import io.qameta.allure.parser.XmlElement;
@@ -44,6 +45,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.entity.LabelName.RESULT_FORMAT;
@@ -89,6 +92,7 @@ public class JunitXmlPlugin implements Reader {
     private static final String TIMESTAMP_ATTRIBUTE_NAME = "timestamp";
     private static final String STATUS_ATTRIBUTE_NAME = "status";
     private static final String SKIPPED_ATTRIBUTE_VALUE = "notrun";
+    private static final String SYSTEM_OUTPUT_ELEMENT_NAME = "system-out";
 
     private static final String XML_GLOB = "*.xml";
 
@@ -157,7 +161,7 @@ public class JunitXmlPlugin implements Reader {
                 .setTimestamp(getUnix(timestamp));
         testSuiteElement.get(TEST_CASE_ELEMENT_NAME)
                 .forEach(element -> parseTestCase(info, element,
-                        resultsDirectory, parsedFile, context, visitor));
+                                                  resultsDirectory, parsedFile, context, visitor));
     }
 
     private Long getUnix(final String timestamp) {
@@ -176,15 +180,21 @@ public class JunitXmlPlugin implements Reader {
         result.setStatus(status);
         result.setFlaky(isFlaky(testCaseElement));
         setStatusDetails(result, testCaseElement);
-
+        final StageResult stageResult = new StageResult();
+        getLogMessage(testCaseElement).ifPresent(logMessage -> {
+            final List<String> lines = splitLines(logMessage);
+            final List<Step> steps = lines
+                    .stream()
+                    .map(line -> new Step().setName(line))
+                    .collect(Collectors.toList());
+            stageResult.setSteps(steps);
+        });
         getLogFile(resultsDirectory, className)
                 .filter(Files::exists)
                 .map(visitor::visitAttachmentFile)
                 .map(attachment1 -> attachment1.setName("System out"))
-                .ifPresent(attachment -> result.setTestStage(
-                        new StageResult().setAttachments(singletonList(attachment))
-                ));
-
+                .ifPresent(attachment -> stageResult.setAttachments(singletonList(attachment)));
+        result.setTestStage(stageResult);
         visitor.visitTestResult(result);
 
         RETRIES.forEach((elementName, retryStatus) -> testCaseElement.get(elementName).forEach(failure -> {
@@ -195,6 +205,14 @@ public class JunitXmlPlugin implements Reader {
             retried.setStatusTrace(failure.getValue());
             visitor.visitTestResult(retried);
         }));
+    }
+
+    private List<String> splitLines(final String str) {
+        return Arrays.asList(str.split("\\r?\\n"));
+    }
+
+    private Optional<String> getLogMessage(final XmlElement testCaseElement) {
+        return testCaseElement.getFirst(SYSTEM_OUTPUT_ELEMENT_NAME).map(XmlElement::getValue);
     }
 
     private Optional<Path> getLogFile(final Path resultsDirectory, final String className) {

--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -192,21 +192,36 @@ class JunitXmlPluginTest {
     }
 
     @Test
-    void shouldReadCdataMessage() throws Exception {
+    void shouldReadStatusMessage() throws Exception {
         process(
                 "junitdata/TEST-test.CdataMessage.xml", "TEST-test.SampleTest.xml"
         );
 
 
         final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
-        verify(visitor, times(1)).visitTestResult(captor.capture());
+        verify(visitor, times(2)).visitTestResult(captor.capture());
 
         assertThat(captor.getAllValues())
                 .extracting(TestResult::getStatusMessage, TestResult::getStatusTrace)
                 .containsExactlyInAnyOrder(
-                        tuple("some-message", "some-trace")
+                        tuple("some-message", "some-trace"),
+                        tuple(null,null)
                 );
+    }
 
+    @Test
+    void shouldReadSystemOutMessage() throws Exception {
+        process(
+                "junitdata/TEST-test.CdataMessage.xml", "TEST-test.SampleTest.xml"
+        );
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(2)).visitTestResult(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .filteredOn(result -> result.getTestStage().getSteps().size() == 2)
+                .filteredOn(result -> result.getTestStage().getSteps().get(0).getName().equals("output"))
+                .filteredOn(result -> result.getTestStage().getSteps().get(1).getName().equals("more output"));
     }
 
     @Issue("532")

--- a/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.CdataMessage.xml
+++ b/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.CdataMessage.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite tests="1" failures="0" name="test.SampleTest" time="1.051" errors="0" skipped="0">
-  <testcase classname="test.SampleTest" name="shouldGenerate" time="1.051">
-    <failure message="some-message"><![CDATA[some-trace]]></failure>
-  </testcase>
+<testsuite tests="2" failures="0" name="test.SampleTest" time="2.055" errors="0" skipped="0">
+    <testcase classname="test.SampleTest" name="shouldGenerateSystemOutOnError" time="1.051">
+        <system-out><![CDATA[output
+more output]]></system-out>
+        <failure message="some-message"><![CDATA[some-trace]]></failure>
+    </testcase>
+    <testcase classname="test.SampleTest" name="shouldGenerateSystemOut" time="1.004">
+        <system-out><![CDATA[test output]]></system-out>
+    </testcase>
 </testsuite>


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Previously, the standard output contained in the JUnit xml files was ignored by the junit-xml plugin.
Now, the plugin appends this output to the test steps.
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
