### PR TITLE
Fix allure.api.translate for plugins

### DIFF
--- a/allure-generator/src/main/javascript/utils/pluginsRegistry.js
+++ b/allure-generator/src/main/javascript/utils/pluginsRegistry.js
@@ -36,7 +36,7 @@ class AllurePluginsRegistry {
     }
 
     translate(name, options) {
-        translate(name, options);
+        return translate(name, options);
     }
 
     addTestResultBlock(view, {position}) {


### PR DESCRIPTION
My first github PR, probably code is not perfect

I am creating allure plugin (and newbie to js). Documentation to allure2 states, that allure.api.translate should translate, but returns undefined. Debugging in browser shows, that value perfectly translated and thrown away in this function. Let's fix it!