### PR TITLE
Preserve order of environment items loaded from files

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/allure1/Allure1Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure1/Allure1Plugin.java
@@ -53,7 +53,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -512,12 +512,15 @@ public class Allure1Plugin implements Reader {
 
     private Map<String, String> processEnvironmentProperties(final Path directory) {
         final Path envPropsFile = directory.resolve("environment.properties");
-        final Map<String, String> items = new HashMap<>();
+        final Map<String, String> items = new LinkedHashMap<>();
         if (Files.exists(envPropsFile)) {
             try (InputStream is = Files.newInputStream(envPropsFile)) {
-                final Properties properties = new Properties();
-                properties.load(is);
-                properties.forEach((key, value) -> items.put(String.valueOf(key), String.valueOf(value)));
+                new Properties() {
+                    @Override
+                    public Object put(final Object key, final Object value) {
+                        return items.put((String) key, (String) value);
+                    }
+                }.load(is);
             } catch (IOException e) {
                 LOGGER.error("Could not read environments.properties file " + envPropsFile, e);
             }
@@ -527,7 +530,7 @@ public class Allure1Plugin implements Reader {
 
     private Map<String, String> processEnvironmentXml(final Path directory) {
         final Path envXmlFile = directory.resolve("environment.xml");
-        final Map<String, String> items = new HashMap<>();
+        final Map<String, String> items = new LinkedHashMap<>();
         if (Files.exists(envXmlFile)) {
             try (InputStream fis = Files.newInputStream(envXmlFile)) {
                 xmlMapper.readValue(fis, ru.yandex.qatools.commons.model.Environment.class).getParameter().forEach(p ->

--- a/allure-generator/src/main/java/io/qameta/allure/environment/Allure1EnvironmentPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/environment/Allure1EnvironmentPlugin.java
@@ -20,7 +20,7 @@ import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.EnvironmentItem;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,11 +45,11 @@ public class Allure1EnvironmentPlugin extends CommonJsonAggregator {
     protected List<EnvironmentItem> getData(final List<LaunchResults> launches) {
         final List<Map.Entry<String, String>> launchEnvironments = launches.stream()
                 .flatMap(launch -> launch.getExtra(ENVIRONMENT_BLOCK_NAME,
-                        (Supplier<Map<String, String>>) HashMap::new).entrySet().stream())
+                        (Supplier<Map<String, String>>) LinkedHashMap::new).entrySet().stream())
                 .collect(toList());
 
         return launchEnvironments.stream()
-                .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, toSet())))
+                .collect(groupingBy(Map.Entry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, toSet())))
                 .entrySet().stream()
                 .map(Allure1EnvironmentPlugin::aggregateItem)
                 .collect(toList());

--- a/allure-generator/src/test/java/io/qameta/allure/environment/Allure1EnvironmentPluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/environment/Allure1EnvironmentPluginTest.java
@@ -71,7 +71,7 @@ class Allure1EnvironmentPluginTest {
                 .as("Unexpected environment properties have been read from properties file")
                 .hasSize(3)
                 .usingFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(expected);
+                .containsExactly(expected);
     }
 
     @Test


### PR DESCRIPTION
The order of environment items loaded from JSON and XML files is not preserved when they are displayed in the report. This PR aims to preserve the original order.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
