### PR TITLE
Adding tests to ensure timestamps are correctly parsed no matter their precision

### DIFF
--- a/allure-plugin-api/src/test/java/io/qameta/allure/datetime/LocalDateTimeParserTest.java
+++ b/allure-plugin-api/src/test/java/io/qameta/allure/datetime/LocalDateTimeParserTest.java
@@ -38,6 +38,12 @@ class LocalDateTimeParserTest {
                 .hasValue(1507199782000L);
     }
 
+    @Test 
+    void shouldParseLocalDateTimeWithNanoseconds() { 
+        final Optional<Long> parsed = new LocalDateTimeParser(ZoneOffset.UTC).getEpochMilli("2019-09-24T01:19:42.578340"); 
+        assertThat(parsed).hasValue(1569287982578L); 
+    } 
+ 
     @Test
     void shouldChangeZone() {
         final ZoneId pst = ZoneId.of(ZoneId.SHORT_IDS.get("PST"));

--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -257,7 +257,7 @@ class JunitXmlPluginTest {
                 .extracting(TestResult::getTime)
                 .extracting(Time::getStart, Time::getStop, Time::getDuration)
                 .containsExactlyInAnyOrder(
-                        tuple(1507199782000L, 1507199783051L, 1051L)
+                        tuple(1507199782999L, 1507199784050L, 1051L)
                 );
     }
 

--- a/plugins/junit-xml-plugin/src/test/resources/junitdata/with-timestamp.xml
+++ b/plugins/junit-xml-plugin/src/test/resources/junitdata/with-timestamp.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuite errors="14" failures="10" hostname="cbgtalosbld02" id="0" name="LocalSuiteIDOL" package="com.zantaz.junit.testsuites" tests="1251" time="391.212" timestamp="2017-10-05T10:36:22">
+<testsuite errors="14" failures="10" hostname="cbgtalosbld02" id="0" name="LocalSuiteIDOL" package="com.zantaz.junit.testsuites" tests="1251" time="391.212" timestamp="2017-10-05T10:36:22.999999">
   <testcase classname="test.SampleTest" name="shouldGenerate" time="1.051"/>
 </testsuite>


### PR DESCRIPTION
Adds tests to ensure timestamps are correctly parsed no matter their precision:
* ensures  #1011 does not occur again


### Context
Timestamp unit tests were not testing cases with precision beyond seconds which can happen if the file was generated by `pytest` for instance.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x ] Provide unit tests


