### PR TITLE
Fix to apply sorting only to suites at Suites tab

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/TreeView.js
+++ b/allure-generator/src/main/javascript/components/tree/TreeView.js
@@ -40,7 +40,7 @@ class TreeView extends View {
         const filter = mix(byText(searchQuery), byStatuses(visibleStatuses), byMark(visibleMarks));
 
         const sortSettings = this.settings.getTreeSorting();
-        const sorter = getComparator(sortSettings);
+        const sorter = getComparator({...sortSettings, groupOnly: true});
 
         this.collection.applyFilterAndSorting(filter, sorter);
     }

--- a/allure-generator/src/main/javascript/data/tree/comparator.js
+++ b/allure-generator/src/main/javascript/data/tree/comparator.js
@@ -32,31 +32,31 @@ function byGroupStatuses(a, b) {
     }, 0);
 }
 
-function compare(a, b, nodeCmp, groupCmp, direction) {
+function compare(a, b, nodeCmp, groupCmp, direction, groupOnly) {
     if (a.children && !b.children) {
         return -1;
     } else if (!a.children && b.children) {
         return 1;
     } else if (a.children && b.children) {
         return direction * groupCmp(a, b);
-    } else if (!a.children && !b.children) {
+    } else if (!a.children && !b.children && !groupOnly) {
         return direction * nodeCmp(a, b);
     } else {
         return 0;
     }
 }
 
-export default function getComparator({sorter, ascending}) {
+export default function getComparator({sorter, ascending, groupOnly}) {
     const direction =  ascending ? 1 : -1;
     switch (sorter) {
         case 'sorter.order':
-            return (a, b) => compare(a, b, byOrder, byName, direction);
+            return (a, b) => compare(a, b, byOrder, byName, direction, groupOnly);
         case 'sorter.name':
-            return (a, b) => compare(a, b, byName, byName, direction);
+            return (a, b) => compare(a, b, byName, byName, direction, groupOnly);
         case 'sorter.duration':
-            return (a, b) => compare(a, b, byDuration, byMaxDuration, direction);
+            return (a, b) => compare(a, b, byDuration, byMaxDuration, direction, groupOnly);
         case 'sorter.status':
-            return (a, b) => compare(a, b, byNodeStatus, byGroupStatuses, direction);
+            return (a, b) => compare(a, b, byNodeStatus, byGroupStatuses, direction, groupOnly);
         default:
             return 0;
     }


### PR DESCRIPTION
### Context
1) From a user perspective it seems a bit weird that when we apply sorting at Suites level for example by duration, nested tests are also sorted by duration, and then, to see the actual test executions sequence, we have to sort once again by order. I believe that some additional sorting strategy should be added for tests to make usage more convenient.
2) These changes make sortable only suites (high level nodes) on the Suites tab

#### Checklist
- [x] [Sign Allure CLA][cla]
- [-] Provide unit tests (no tests found for JS in allure-generator module)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
