### PR TITLE
Point tests from Timeline tab to tests from Suites tab to improve further navigation

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/suites/SuitesPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/suites/SuitesPlugin.java
@@ -22,6 +22,8 @@ import io.qameta.allure.Constants;
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.csv.CsvExportSuite;
 import io.qameta.allure.entity.TestResult;
+import io.qameta.allure.tree.SuitesTestResultGroupFactory;
+import io.qameta.allure.tree.TestResultLeafFactory;
 import io.qameta.allure.tree.TestResultTree;
 import io.qameta.allure.tree.TestResultTreeGroup;
 import io.qameta.allure.tree.Tree;
@@ -74,7 +76,9 @@ public class SuitesPlugin extends CompositeAggregator {
         // @formatter:off
         final Tree<TestResult> xunit = new TestResultTree(
                 SUITES,
-            testResult -> groupByLabels(testResult, PARENT_SUITE, SUITE, SUB_SUITE)
+            testResult -> groupByLabels(testResult, PARENT_SUITE, SUITE, SUB_SUITE),
+            new SuitesTestResultGroupFactory(),
+            new TestResultLeafFactory()
         );
         // @formatter:on
 

--- a/allure-generator/src/main/javascript/plugins/tab-timeline/TimelineView.js
+++ b/allure-generator/src/main/javascript/plugins/tab-timeline/TimelineView.js
@@ -223,7 +223,10 @@ class TimelineView extends BaseChartView {
         .data(items)
         .enter()
         .append("a")
-        .attr("xlink:href", (d) => `#testresult/${d.uid}`)
+        .attr('xlink:href', (d) => {
+          const href = d.suiteUid ? `#suites/${d.suiteUid}/` : '#testresult/';
+          return href + d.uid;
+        })
         .append("rect")
         .attrs({
           class: (d) => `timeline__item chart__fill_status_${d.status}`,

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -197,6 +197,30 @@ class Allure2PluginTest {
     }
 
     @Test
+    void shouldProcessSuite() throws Exception {
+        Set<TestResult> testResults = process(
+                "allure2/simple-testcase-with-suite.json", generateTestResultName()
+        ).getResults();
+
+        assertThat(testResults)
+                .hasSize(1);
+        assertThat(testResults.iterator().next().getSuiteUid())
+                .isNotBlank();
+    }
+
+    @Test
+    void shouldNotProcessSuite() throws Exception {
+        Set<TestResult> testResults = process(
+                "allure2/simple-testcase.json", generateTestResultName()
+        ).getResults();
+
+        assertThat(testResults)
+                .hasSize(1);
+        assertThat(testResults.iterator().next().getSuiteUid())
+                .isNull();
+    }
+
+    @Test
     void shouldProcessInvalidStatus() throws Exception {
         Set<TestResult> testResults = process(
                 "allure2/invalid-status.json", generateTestResultName()

--- a/allure-generator/src/test/resources/allure2/simple-testcase-with-suite.json
+++ b/allure-generator/src/test/resources/allure2/simple-testcase-with-suite.json
@@ -1,0 +1,22 @@
+{
+  "uuid": "93542b02b4f3b5c69033c3643e0428ed",
+  "status": "passed",
+  "name": "shouldCreate",
+  "start": 1479552611395,
+  "stop": 1479552611399,
+  "steps" : [ {
+    "status" : "passed",
+    "name" : "someSimpleStep",
+    "start" : 1479552601335,
+    "stop" : 1479552601337,
+    "attachments" : [ {
+      "name" : "String attachment in test",
+      "source" : "test-sample-attachment.txt",
+      "type" : "text/plain"
+    }]
+  }],
+  "labels" : [ {
+    "name" : "suite",
+    "value": "MySuite"  
+  } ]
+}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
@@ -44,6 +44,7 @@ public class TestResult implements Serializable, Nameable, Parameterizable, Stat
     private static final long serialVersionUID = 1L;
 
     protected String uid;
+    protected String suiteUid;
     protected String name;
     protected String fullName;
     protected String historyId;

--- a/allure-plugin-api/src/main/java/io/qameta/allure/tree/SuitesTestResultGroupFactory.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/tree/SuitesTestResultGroupFactory.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.tree;
+
+import io.qameta.allure.entity.TestResult;
+
+/**
+ * @author uladzislau_arlouski
+ *
+ */
+public class SuitesTestResultGroupFactory implements TreeGroupFactory<TestResult, TestResultTreeGroup> {
+
+    @Override
+    public TestResultTreeGroup create(final TestResultTreeGroup parent, final String name, final TestResult item) {
+        return new TestResultTreeGroup(item.getSuiteUid(), name);
+    }
+}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/tree/TestResultTreeLeaf.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/tree/TestResultTreeLeaf.java
@@ -28,6 +28,8 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
 
     private final String uid;
 
+    private final String suiteUid;
+
     private final String parentUid;
 
     private final Status status;
@@ -52,6 +54,7 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
         super(name);
         this.parentUid = parentUid;
         this.uid = testResult.getUid();
+        this.suiteUid = testResult.getSuiteUid();
         this.status = testResult.getStatus();
         this.time = testResult.getTime();
         this.flaky = testResult.isFlaky();
@@ -65,6 +68,10 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
 
     public String getUid() {
         return uid;
+    }
+
+    public String getSuiteUid() {
+        return suiteUid;
     }
 
     public Status getStatus() {


### PR DESCRIPTION
### Context
If we click on a test on the timeline, that brings us to a page containing only test information without any references to a parent suite, this fix makes the click action to redirect us to the Suites tab with all the related to the test data

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
