### PR TITLE
Change plugin history limit to 20

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
@@ -156,7 +156,7 @@ public class HistoryPlugin implements Reader, Aggregator {
         }
 
         final List<HistoryItem> newItems = Stream.concat(Stream.of(newItem), data.getItems().stream())
-                .limit(5)
+                .limit(20)
                 .collect(Collectors.toList());
         result.setNewFailed(isNewFailed(newItems));
         result.setFlaky(isFlaky(newItems));


### PR DESCRIPTION
Since there has been an ongoing conversation about the history limit, I decided to change the plugin limit to 20. This would probably be enough for now until there is a proper way to configure it. 

Related Issues are: 
https://github.com/allure-framework/allure2/issues/347
https://github.com/allure-framework/allure2/issues/906

This is a small change and I can't see why there would be a limit to 5 results so I'd be really happy if this would be merged.