### PR TITLE
TRX-Plugin parses InnerTestResults

### DIFF
--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -68,6 +68,7 @@ public class TrxPlugin implements Reader {
     public static final String TRX_RESULTS_FORMAT = "trx";
     public static final String RESULTS_ELEMENT_NAME = "Results";
     public static final String UNIT_TEST_RESULT_ELEMENT_NAME = "UnitTestResult";
+    public static final String UNIT_TEST_INNER_RESULTS = "InnerResults";
     public static final String TEST_NAME_ATTRIBUTE = "testName";
     public static final String START_TIME_ATTRIBUTE = "startTime";
     public static final String END_TIME_ATTRIBUTE = "endTime";
@@ -213,6 +214,13 @@ public class TrxPlugin implements Reader {
 
         result.addLabelIfNotExists(RESULT_FORMAT, TRX_RESULTS_FORMAT);
         visitor.visitTestResult(result);
+        unitTestResult.getFirst(UNIT_TEST_INNER_RESULTS)
+                    .ifPresent(innerResults -> {
+                        innerResults.get(UNIT_TEST_RESULT_ELEMENT_NAME)
+                                .forEach(unitTestChildResult -> 
+                                    parseUnitTestResult(unitTestChildResult, tests, context, visitor)
+                        );
+        }); 
     }
 
     private List<String> splitLines(final String str) {

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -230,7 +230,6 @@ public class TrxPlugin implements Reader {
                                        final RandomUidContext context,
                                        final ResultsVisitor visitor,
                                        final List<Label> labels) {
-        final String executionId = unitTestResult.getAttribute(EXECUTION_ID_ATTRIBUTE);
         final String testName = unitTestResult.getAttribute(TEST_NAME_ATTRIBUTE);
         final String startTime = unitTestResult.getAttribute(START_TIME_ATTRIBUTE);
         final String endTime = unitTestResult.getAttribute(END_TIME_ATTRIBUTE);

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -19,9 +19,16 @@ import io.qameta.allure.Issue;
 import io.qameta.allure.context.RandomUidContext;
 import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.ResultsVisitor;
+import io.qameta.allure.entity.Label;
 import io.qameta.allure.entity.LabelName;
 import io.qameta.allure.entity.Status;
 import io.qameta.allure.entity.TestResult;
+
+import static io.qameta.allure.entity.LabelName.RESULT_FORMAT;
+import static io.qameta.allure.entity.LabelName.PACKAGE;
+import static io.qameta.allure.entity.LabelName.SUITE;
+import static io.qameta.allure.entity.LabelName.TEST_CLASS;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,8 +38,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -159,6 +168,19 @@ class TrxPluginTest {
                         tuple("UnitTest_Three (Child Two)", Status.FAILED),
                         tuple("UnitTest_Three (Child Two) (GrandChild One)", Status.PASSED),
                         tuple("UnitTest_Three (Child Two) (GrandChild Two)", Status.FAILED)
+                );
+
+        List<Label> labels = new ArrayList<>();
+        labels.add(new Label().setName(SUITE.value()).setValue("Test"));
+        labels.add(new Label().setName(TEST_CLASS.value()).setValue("Test"));
+        labels.add(new Label().setName(PACKAGE.value()).setValue("Test"));
+        labels.add(new Label().setName(RESULT_FORMAT.value()).setValue("trx"));
+
+        assertThat(captor.getAllValues())
+                .filteredOn(result -> result.getName().contains("UnitTest_Three"))
+                .extracting(TestResult::getLabels)
+                .containsOnly(
+                        labels
                 );
 
     }

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -138,6 +138,31 @@ class TrxPluginTest {
                 .hasSize(1);
     }
 
+    @Test
+    void shouldParseTestResultChildren() throws Exception {
+        process(
+                "trxdata/testresultsWithChildren.trx",
+                "sample.trx"
+        );
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(7)).visitTestResult(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .hasSize(7)
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("UnitTest_One", Status.PASSED),
+                        tuple("UnitTest_Two", Status.PASSED),
+                        tuple("UnitTest_Three", Status.FAILED),
+                        tuple("UnitTest_Three (Child One)", Status.FAILED),
+                        tuple("UnitTest_Three (Child Two)", Status.FAILED),
+                        tuple("UnitTest_Three (Child Two) (GrandChild One)", Status.PASSED),
+                        tuple("UnitTest_Three (Child Two) (GrandChild Two)", Status.FAILED)
+                );
+
+    }
+
     private void process(String... strings) throws IOException {
         Iterator<String> iterator = Arrays.asList(strings).iterator();
         while (iterator.hasNext()) {

--- a/plugins/trx-plugin/src/test/resources/trxdata/testresultsWithChildren.trx
+++ b/plugins/trx-plugin/src/test/resources/trxdata/testresultsWithChildren.trx
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="3fbf31be-860e-489c-961a-961578280418" name="@computerName 2020-04-23 13:44:25" runUser="TestUser" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2020-04-23T13:44:25.3601822+02:00" queuing="2020-04-23T13:44:25.3601822+02:00" start="2020-04-23T13:43:32.9220803+02:00" finish="2020-04-23T13:44:25.8753504+02:00" />
+  <TestSettings name="default" id="309ac945-c794-4407-89fd-2b38e6b8d733">
+    <Deployment runDeploymentRoot="_computerName_2020-04-23_13_44_25" />
+  </TestSettings>
+  <Results>
+    <UnitTestResult executionId="c95d1648-d3d0-4173-9f1a-5bd2d28203c3" testId="6719dfe8-c2eb-2cb5-b08d-9033899d1a4b" testName="UnitTest_One" computerName="computerName" duration="00:00:00.1618538" startTime="2020-04-23T13:44:25.4379697+02:00" endTime="2020-04-23T13:44:25.5940824+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c95d1648-d3d0-4173-9f1a-5bd2d28203c3">
+    </UnitTestResult>
+    <UnitTestResult executionId="2fd4e892-4120-4b49-b156-1c1f758f2c16" testId="a99380c3-7aea-b148-8367-b8064f2967fa" testName="UnitTest_Two" computerName="computerName" duration="00:00:00.0794423" startTime="2020-04-23T13:44:25.5940824+02:00" endTime="2020-04-23T13:44:25.6721877+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2fd4e892-4120-4b49-b156-1c1f758f2c16">
+    </UnitTestResult>
+    <UnitTestResult executionId="e9138185-a15a-4b71-bd8c-fff05c7b19cb" testId="0e355212-4172-2c5e-0288-b9c87dee283b" testName="UnitTest_Three" computerName="computerName" duration="00:00:51.9722792" startTime="2020-04-23T13:43:33.2191130+02:00" endTime="2020-04-23T13:44:25.3445564+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e9138185-a15a-4b71-bd8c-fff05c7b19cb" resultType="DataDrivenTest">
+      <InnerResults>
+        <UnitTestResult executionId="17b33756-44a1-47de-9291-c3a9287d5740" parentExecutionId="e9138185-a15a-4b71-bd8c-fff05c7b19cb" testId="0e355212-4172-2c5e-0288-b9c87dee283b" testName="UnitTest_Three (Child One)" computerName="computerName" duration="00:00:51.8914452" startTime="2020-04-23T13:43:33.2191130+02:00" endTime="2020-04-23T13:44:25.3445564+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="17b33756-44a1-47de-9291-c3a9287d5740" dataRowInfo="1" resultType="DataDrivenDataRow">
+          <Output>
+            <ErrorInfo>
+              <Message>Some Message. </Message>
+              <StackTrace> Some Trace. </StackTrace>
+            </ErrorInfo>
+          </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="bfb6e97d-b108-4198-aae1-e899e22072ad" parentExecutionId="e9138185-a15a-4b71-bd8c-fff05c7b19cb" testId="0e355212-4172-2c5e-0288-b9c87dee283b" testName="UnitTest_Three (Child Two)" computerName="computerName" duration="00:00:00.0599399" startTime="2020-04-23T13:43:33.2191130+02:00" endTime="2020-04-23T13:44:25.3445564+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="bfb6e97d-b108-4198-aae1-e899e22072ad" dataRowInfo="2" resultType="DataDrivenDataRow"> 
+          <InnerResults>
+            <UnitTestResult executionId="a60a11b3-8f2f-44d3-8e20-2dcbd89e29df" parentExecutionId="bfb6e97d-b108-4198-aae1-e899e22072ad" testId="0e355212-4172-2c5e-0288-b9c87dee283b" testName="UnitTest_Three (Child Two) (GrandChild One)" computerName="computerName" duration="00:00:00.0181125" startTime="2020-04-23T13:43:33.2191130+02:00" endTime="2020-04-23T13:44:25.3445564+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a60a11b3-8f2f-44d3-8e20-2dcbd89e29df">
+            </UnitTestResult>
+            <UnitTestResult executionId="fb719322-050c-4233-b018-58ef7033a289" parentExecutionId="bfb6e97d-b108-4198-aae1-e899e22072ad" testId="f3960422-1dc5-b6b4-2cb9-861ad091694c" testName="UnitTest_Three (Child Two) (GrandChild Two)" computerName="computerName" duration="00:00:00.0387858" startTime="2020-04-23T13:44:25.3913200+02:00" endTime="2020-04-23T13:44:25.4379697+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fb719322-050c-4233-b018-58ef7033a289">
+              <Output>
+                <ErrorInfo>
+                    <Message>Second Message. </Message>
+                    <StackTrace> Second Trace. </StackTrace>
+                </ErrorInfo>
+              </Output>
+            </UnitTestResult>
+          </InnerResults>
+        </UnitTestResult>
+      </InnerResults>
+    </UnitTestResult>
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="UnitTest_One" storage="D:\Test\Test.dll" id="6719dfe8-c2eb-2cb5-b08d-9033899d1a4b">
+      <Execution id="c95d1648-d3d0-4173-9f1a-5bd2d28203c3" />
+      <TestMethod codeBase="D:\Test\Test.dll" adapterTypeName="executor://mstestadapter/v2" className="Test" name="UnitTest_One" />
+    </UnitTest>
+    <UnitTest name="UnitTest_Two" storage="D:\Test\Test.dll" id="a99380c3-7aea-b148-8367-b8064f2967fa">
+      <Execution id="2fd4e892-4120-4b49-b156-1c1f758f2c16" />
+      <TestMethod codeBase="D:\Test\Test.dll" adapterTypeName="executor://mstestadapter/v2" className="Test" name="UnitTest_Two" />
+    </UnitTest>
+    <UnitTest name="UnitTest_Three" storage="D:\Test\Test.dll" id="0e355212-4172-2c5e-0288-b9c87dee283b">
+      <Execution id="e9138185-a15a-4b71-bd8c-fff05c7b19cb" />
+      <TestMethod codeBase="D:\Test\Test.dll" adapterTypeName="executor://mstestadapter/v2" className="Test" name="UnitTest_Three" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestEntries>
+    <TestEntry testId="6719dfe8-c2eb-2cb5-b08d-9033899d1a4b" executionId="c95d1648-d3d0-4173-9f1a-5bd2d28203c3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a99380c3-7aea-b148-8367-b8064f2967fa" executionId="2fd4e892-4120-4b49-b156-1c1f758f2c16" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0e355212-4172-2c5e-0288-b9c87dee283b" executionId="e9138185-a15a-4b71-bd8c-fff05c7b19cb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <TestLists>
+    <TestList name="Ergebnisse nicht in einer Liste" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="Alle geladenen Ergebnisse" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Failed">
+    <Counters total="7" executed="7" passed="3" failed="4" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+  </ResultSummary>
+</TestRun>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
UnitTestResults can be nested. Nested Results are contained in an InnerResults-tag. The TRX-Plugin did not lookup the UnitTestResults for these nested results.
I implemented a recursive lookup for these results.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
