### PR TITLE
Fix for an issue with expanding of previous expanded test items when a user clicks on a different item (fixes #575)

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/TreeView.js
+++ b/allure-generator/src/main/javascript/components/tree/TreeView.js
@@ -113,7 +113,11 @@ class TreeView extends View {
             el.toggleClass('node__expanded', this.state.has(uid));
         });
         this.$('.node__title_active').parents('.node').toggleClass('node__expanded', true);
-        this.$('.node__expanded').parents('.node').toggleClass('node__expanded', true);
+        if (this.$('.node').parents('.node__expanded').length > 0) {
+            this.$('.node__expanded').parents('div.node.node__expanded').toggleClass('node__expanded', true);
+        } else {
+            this.$('.node__expanded').parents('.node').toggleClass('node__expanded', true);
+        }
     }
 
     findElement(treeNode) {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
Fixes #575

Tested in 
* "Packages" tab:
http://g.recordit.co/NUufDrbKLy.gif
* "Suites" tab:
http://g.recordit.co/iObiDeMLNL.gif
* "Behaviors" tab:
http://g.recordit.co/19kLz9gGP3.gif
* "Categories" tab:
http://g.recordit.co/MgSYUlJ9Co.gif

Also, these changes fix an issue with expanding previously expanded nodes when a user clicks on tabs ("Overview", "History", "Retries") in the test-results area (http://g.recordit.co/NB95hcOzbk.gif). 
Now it looks like http://g.recordit.co/X1JaNUpKYq.gif

P.S. I hope that these changes will improve the daily work with Allure. I spend a lot of time with Allure report and these changes will be very useful ;)

#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
