### PR TITLE
Don't set flakiness to false when other plugins have already set it to true (fixes #910)

### DIFF
--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
@@ -71,6 +71,27 @@ public class TestResult implements Serializable, Nameable, Parameterizable, Stat
     protected boolean retry;
     protected final Map<String, Object> extra = new HashMap<>();
 
+
+    public TestResult resetFlaky() {
+        this.flaky = false;
+        return this;
+    }
+
+    /**
+     * Sets the TestResult's flaky status
+     * 
+     * Performs logical OR on existing flakiness so that other plugins that
+     * have previously set flakiness don't get their value overwritten 'falsely'
+     *
+     * Trying to deliberatey set flakiness to false? use {@link #resetFlaky()}
+     * 
+     * @param flakeStatus Flaky status
+     */
+    public TestResult setFlaky(final boolean flakeStatus) {
+        this.flaky = flakeStatus || this.flaky;
+        return this;
+    }
+
     @JsonProperty
     public String getSource() {
         return getUid() + ".json";


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

This PR does not address all of the wants that have been discussed in https://github.com/allure-framework/allure2/issues/910 but it does fix the original issue. Because https://github.com/allure-framework/allure2/pull/871 added the functionality for the history plugin to determine flakiness, it would blow away any other plugins that set flakiness for a test suite. This behavior is a defect in itself because it only happened as HistoryPlugin is listed later than RetryPlugin here https://github.com/allure-framework/allure2/blob/b64437f8b5bf5fa318286c9ae136a40d87baa9c2/allure-generator/src/main/java/io/qameta/allure/DummyReportGenerator.java#L81-L113

Given that the [current documentation says that retried tests are marked as flaky](https://docs.qameta.io/allure/#_retries), I believe that this PR is necessary to make the docs accurate again.

I tested by modifying one of the demos that had an existing test which retried, and set one of the results to `Passed`
![image](https://user-images.githubusercontent.com/41299660/93133755-b7170f80-f6a5-11ea-9b98-26f92d00e85d.png)
![image](https://user-images.githubusercontent.com/41299660/93134848-5b4d8600-f6a7-11ea-89b7-72d10b833319.png)

Here are more issues that could be closed after this PR is merged
https://github.com/allure-framework/allure2/issues/925
https://github.com/allure-framework/allure-java/issues/452 (although I don't think this fixes the 'skipped' issue)
https://github.com/allure-framework/allure-java/issues/463
https://github.com/allure-framework/allure-java/issues/127 (this one is super old but there appears to have been interest this year)


On the same note, I believe a valid feature request would be to allow for plugins to give a `FlakyReason` string to a flaky suite, and display this list of reasons when hovering over the flaky bomb (whereas now it only says `Test is flaky`).

Edit: It would also seem that any custom plugins the users attempted to use would also have their flakiness blown away as custom plugins are loaded first in the array 
https://github.com/allure-framework/allure2/blob/b64437f8b5bf5fa318286c9ae136a40d87baa9c2/allure-generator/src/main/java/io/qameta/allure/DummyReportGenerator.java#L141-L148

 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
