### PR TITLE
Add Dutch translation

### DIFF
--- a/allure-generator/src/main/javascript/translations/nl.json
+++ b/allure-generator/src/main/javascript/translations/nl.json
@@ -1,0 +1,205 @@
+{
+  "status": {
+    "failed": "Gefaald",
+    "broken": "Kapot",
+    "passed": "Geslaagd",
+    "skipped": "Overgeslagen",
+    "unknown": "Onbekend",
+    "flaky": "Test is instabiel",
+    "newFailed": "Test is nieuw gefaald"
+  },
+  "marks": {
+    "flaky": "Instabiel",
+    "newFailed": "Nieuw gefaald"
+  },
+  "sorter": {
+    "order": "volgorde",
+    "name": "naam",
+    "duration": "duur",
+    "status": "status"
+  },
+  "tab": {
+    "overview": {
+      "name": "Overzicht"
+    },
+    "categories": {
+      "name": "Categorieën"
+    },
+    "suites": {
+      "name": "Suites"
+    },
+    "graph": {
+      "name": "Grafieken"
+    },
+    "timeline": {
+      "name": "Tijdlijn",
+      "selected": "{{count}} test ({{percent}}%) geselecteerd met een duur van meer dan {{duration}}",
+      "selected_plural": "{{count}} tests ({{percent}}%) geselecteerd met een duur van meer dan {{duration}}"
+    }
+  },
+  "widget": {
+    "summary": {
+      "aggregatedName": "Geaggregeerd rapport",
+      "launches": "start",
+      "launches_plural": "starts",
+      "testResults": "testgeval",
+      "testResults_plural": "testgevallen"
+    },
+    "trend": {
+      "name": "Trend"
+    },
+    "categoriesTrend": {
+      "name": "Trend categorieën"
+    },
+    "durationTrend": {
+      "name": "Trend duur"
+    },
+    "retryTrend": {
+      "name": "Trend nieuwe pogingen"
+    },
+    "executors": {
+      "name": "Uitvoerders",
+      "unknown": "Onbekend",
+      "empty": "Er is geen informatie over testuitvoerders"
+    },
+    "launches": {
+      "name": "Start",
+      "empty": "Er is geen informatie over starts"
+    },
+    "environment": {
+      "name": "Omgeving",
+      "empty": "Er zijn geen omgevingsvariabelen",
+      "showAll": "Toon alle"
+    },
+    "suites": {
+      "name": "Suites"
+    },
+    "categories": {
+      "name": "Categorieën"
+    }
+  },
+  "chart": {
+    "duration": {
+      "name": "Duur",
+      "empty": "Er is niets te tonen"
+    },
+    "trend": {
+      "empty": "Er is niets te tonen"
+    },
+    "severity": {
+      "name": "Ernst"
+    },
+    "status": {
+      "name": "Status"
+    }
+  },
+  "testResult": {
+    "status": {
+      "empty": "Lege statusdetails",
+      "trace": "Toon trace"
+    },
+    "overview": {
+      "name": "Overzicht"
+    },
+    "categories": {
+      "name": "Categorieën"
+    },
+    "description": {
+      "name": "Omschrijving"
+    },
+    "duration": {
+      "name": "Duur"
+    },
+    "history": {
+      "name": "Historie",
+      "successRate": "Slagingsratio"
+    },
+    "owner": {
+      "name": "Eigenaar"
+    },
+    "retries": {
+      "name": "Nieuwe pogingen",
+      "empty": "Er is geen informatie over nieuwe testpogingen."
+    },
+    "parameters": {
+      "name": "Parameters"
+    },
+    "links": {
+      "name": "Links"
+    },
+    "severity": {
+      "name": "Ernst"
+    },
+    "execution": {
+      "name": "Uitvoering",
+      "setup": "Set up",
+      "teardown": "Tear down",
+      "body": "Test body"
+    },
+    "stats": {
+      "count": {
+        "steps": "{{count}} substap",
+        "steps_plural": "{{count}} substappen",
+        "attachments": "{{count}} bijlage",
+        "attachments_plural": "{{count}} bijlagen",
+        "parameters": "{{count}} parameter",
+        "parameters_plural": "{{count}} parameters"
+      }
+    }
+  },
+  "controls": {
+    "collapse": "Inklappen",
+    "expand": "Uitklappen",
+    "fullscreen": "Volledig scherm",
+    "language": "Taal wijzigen",
+    "clipboard": "Kopieer naar klembord",
+    "clipboardSuccess": "Gekopieerd naar klembord",
+    "clipboardError": "Kan niet kopiëren naar klembord. De browser lijkt deze functionaliteit niet te ondersteunen.",
+    "backto": "Terug naar"
+  },
+  "errors": {
+    "missedAttachment": "Bijlage niet gevonden",
+    "notFound": "Niet gevonden"
+  },
+  "component": {
+    "tree": {
+      "filter": "Status",
+      "filter-marks": "Markeringen",
+      "groups": "Groepsinformatie tonen/verbergen",
+      "download": "Download CSV",
+      "empty": "Er zijn geen items",
+      "time": {
+        "total" : {
+          "name": "Totaal",
+          "tooltip": "Duur van eerste test gestart tot laatste test beëindigd"
+        },
+        "max": {
+          "name": "Langstdurend",
+          "tooltip": "Duur van de langste test"
+        },
+        "sum": {
+          "name": "Som",
+          "tooltip": "Duur van alle tests opgeteld"
+        }
+      },
+      "filtered": {
+        "total": "{{count}} testresultaat",
+        "total_plural": "{{count}} testresultaten",
+        "shown": "{{count}} getoond"
+      }
+    },
+    "widgetStatus": {
+      "showAll": "Toon alles",
+      "total": "{{count}} item in totaal",
+      "total_plural": "{{count}} items in totaal"
+    },
+    "statusToggle": {
+      "showCases": "Toon testresultaten met status ‘{{status}}’",
+      "hideCases": "Verberg testresultaten met status ’{{status}}’"
+    },
+    "markToggle": {
+      "showCases": "Toon testresultaten gemarkeerd als ‘{{mark}}’",
+      "hideCases": "Verberg testresultaten gemarkeerd als ‘{{mark}}’"
+    }
+  }
+}

--- a/allure-generator/src/main/javascript/utils/translation.js
+++ b/allure-generator/src/main/javascript/utils/translation.js
@@ -6,6 +6,7 @@ export const LANGUAGES = [
     {id: 'ru', title: 'Русский'},
     {id: 'zh', title: '中文'},
     {id: 'de', title: 'Deutsch'},
+    {id: 'nl', title: 'Nederlands'},
     {id: 'he', title: 'Hebrew'},
     {id: 'br', title: 'Brazil'},
     {id: 'pl', title: 'Polski'},

--- a/plugins/behaviors-plugin/src/dist/static/index.js
+++ b/plugins/behaviors-plugin/src/dist/static/index.js
@@ -56,6 +56,20 @@ allure.api.addTranslation('de', {
     }
 });
 
+allure.api.addTranslation('nl', {
+    tab: {
+        behaviors: {
+            name: 'Functionaliteit'
+        }
+    },
+    widget: {
+        behaviors: {
+            name: 'Features en story’s',
+            showAll: 'Toon alle'
+        }
+    }
+});
+
 allure.api.addTranslation('he', {
     tab: {
         behaviors: {

--- a/plugins/packages-plugin/src/dist/static/index.js
+++ b/plugins/packages-plugin/src/dist/static/index.js
@@ -32,6 +32,14 @@ allure.api.addTranslation('de', {
     }
 });
 
+allure.api.addTranslation('nl', {
+    tab: {
+        packages: {
+            name: 'Packages'
+        }
+    }
+});
+
 allure.api.addTranslation('he', {
     tab: {
         packages: {


### PR DESCRIPTION
### Context
Allure was lacking a 🇳🇱 Dutch translation, so I added one. The translation uses terms from the [ISTQB Glossary][glossary] (Werkgroep Glossary ISTQB, 2007)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests (n/a)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
[glossary]: http://www.erikvanveenendaal.nl/NL/files/Standaard%20verklarende%20woordenlijst%20van%20software%20testtermen%20Vertaling%20Engels%20-%20Nederlands.pdf
