### PR TITLE
Fix unsupported browse operation error (fixes #1122)

### DIFF
--- a/allure-commandline/src/main/java/io/qameta/allure/Commands.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/Commands.java
@@ -222,7 +222,7 @@ public class Commands {
                 Desktop.getDesktop().browse(url);
             } catch (UnsupportedOperationException e) {
                 LOGGER.error("Can not open browser because this capability is not supported on "
-                    + "your platform. You can use the link below to open the report manually.");
+                    + "your platform. You can use the link below to open the report manually.", e);
             }
         }
     }

--- a/allure-commandline/src/main/java/io/qameta/allure/Commands.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/Commands.java
@@ -218,10 +218,12 @@ public class Commands {
      */
     protected void openBrowser(final URI url) throws IOException {
         if (Desktop.isDesktopSupported()) {
-            Desktop.getDesktop().browse(url);
-        } else {
-            LOGGER.error("Can not open browser because this capability is not supported on "
+            try {
+                Desktop.getDesktop().browse(url);
+            } catch (UnsupportedOperationException e) {
+                LOGGER.error("Can not open browser because this capability is not supported on "
                     + "your platform. You can use the link below to open the report manually.");
+            }
         }
     }
 


### PR DESCRIPTION
### Context
Although Desktop.isDesktopSupported() is working well in Java with different desktops (Linux, Windows, Macos), browse operation throws an exception not caught in the code if the current desktop doesn't support it.

Issues related: #1122 

#### Checklist
- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
