### PR TITLE
Fix desktop supported error information (Fixes #1163)

### DIFF
--- a/allure-commandline/src/main/java/io/qameta/allure/Commands.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/Commands.java
@@ -221,9 +221,12 @@ public class Commands {
             try {
                 Desktop.getDesktop().browse(url);
             } catch (UnsupportedOperationException e) {
-                LOGGER.error("Can not open browser because this capability is not supported on "
-                    + "your platform. You can use the link below to open the report manually.", e);
+                LOGGER.error("Browse operation is not supported on your platform."
+                    + "You can use the link below to open the report manually.", e);
             }
+        } else {
+            LOGGER.error("Can not open browser because this capability is not supported on "
+                + "your platform. You can use the link below to open the report manually."); 
         }
     }
 


### PR DESCRIPTION
### Context
Error information added to openBrowser method when desktop is not supported.

Fixes #1163 

#### Checklist
- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2