### PR TITLE
[Security] Bump jackson-databind version from 2.9.8 to 2.10.5.1 in /allure-commandline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ configure(subprojects) {
 
     configure<DependencyManagementExtension> {
         imports {
-            mavenBom("com.fasterxml.jackson:jackson-bom:2.9.8")
+            mavenBom("com.fasterxml.jackson:jackson-bom:2.10.5.20201202")
             mavenBom("org.junit:junit-bom:5.4.0")
         }
         dependencies {


### PR DESCRIPTION
bumps jackson-bom version from 2.9.8 to 2.10.5.20201202 for fixing high and critical security related issues in jackson-databind versions lower than 2.10.5.1.

This fix indirectly bumps jackson-databind version to 2.10.5.1

https://blog.sonatype.com/jackson-databind-the-end-of-the-blacklist
https://github.com/advisories/GHSA-288c-cq4h-88gq
https://github.com/advisories/GHSA-f3j5-rmmp-3fc5
