### PR TITLE
Fix RPM package install on Fedora / CentOS

### DIFF
--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -74,9 +74,7 @@ ospackage {
     os = org.redline_rpm.header.Os.LINUX
     release = "1"
 
-    requires("java8-runtime | java8-runtime-headless | " +
-            "openjdk8-jre-headless | openjdk-8-jre | openjdk-8-jdk | " +
-            "oracle-java8-installer | oracle-java8-installer")
+    requires("java-1.8.0")
 
     // Remove closureOf when https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/399 is fixed
     from("${pack}/bin", closureOf<CopySpec> {


### PR DESCRIPTION
### Context

The latest allure rpm package can not be installed on Fedora / CentOS 7 because of invalid java8 requirements:
```
$ sudo dnf install https://github.com/allure-framework/allure2/releases/download/2.14.0/allure_2.14.0-1.noarch.rpm
...
Error: 
 Problem: conflicting requests
  - nothing provides java8-runtime | java8-runtime-headless | openjdk8-jre-headless | openjdk-8-jre | openjdk-8-jdk | oracle-java8-installer | oracle-java8-installer needed by allure-2.14.0-1.noarch
(try to add '--skip-broken' to skip uninstallable packages)
```

Test installs after fix:
* CentOS 7 - https://gist.github.com/gmmephisto/6b299628555c74be7e42cc67cb87acb3
* Fedara 34 - https://gist.github.com/gmmephisto/079e07d88dd262d28beb751f9c254df7
* Opensuse Leap - https://gist.github.com/gmmephisto/cce8bff6acafdd581b15dd9e7172c2c1