### PR TITLE
Make results' limits configurable (fixes #347)

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/category/CategoriesTrendPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/category/CategoriesTrendPlugin.java
@@ -18,6 +18,7 @@ package io.qameta.allure.category;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Aggregator;
 import io.qameta.allure.CommonJsonAggregator;
 import io.qameta.allure.Constants;
 import io.qameta.allure.core.LaunchResults;
@@ -54,7 +55,7 @@ public class CategoriesTrendPlugin extends AbstractTrendPlugin<CategoriesTrendIt
         final List<CategoriesTrendItem> data = getHistoryItems(launchesResults);
 
         return Stream.concat(Stream.of(item), data.stream())
-                .limit(20)
+                .limit(Aggregator.resultsLimit())
                 .collect(Collectors.toList());
     }
 

--- a/allure-generator/src/main/java/io/qameta/allure/duration/DurationTrendPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/duration/DurationTrendPlugin.java
@@ -18,6 +18,7 @@ package io.qameta.allure.duration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Aggregator;
 import io.qameta.allure.CommonJsonAggregator;
 import io.qameta.allure.Constants;
 import io.qameta.allure.core.LaunchResults;
@@ -55,7 +56,7 @@ public class DurationTrendPlugin extends AbstractTrendPlugin<DurationTrendItem> 
         final List<DurationTrendItem> data = getHistoryItems(launchesResults);
 
         return Stream.concat(Stream.of(item), data.stream())
-                .limit(20)
+                .limit(Aggregator.resultsLimit())
                 .collect(Collectors.toList());
     }
 

--- a/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
@@ -189,7 +189,7 @@ public class HistoryPlugin implements Reader, Aggregator {
         result.setNewPassed(isNewPassed(current, prevItems));
 
         final List<HistoryItem> newItems = Stream.concat(Stream.of(current), prevItems.stream())
-                .limit(20)
+                .limit(Aggregator.resultsLimit())
                 .collect(Collectors.toList());
         data.setItems(newItems);
     }

--- a/allure-generator/src/main/java/io/qameta/allure/history/HistoryTrendPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/history/HistoryTrendPlugin.java
@@ -18,6 +18,7 @@ package io.qameta.allure.history;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Aggregator;
 import io.qameta.allure.CommonJsonAggregator;
 import io.qameta.allure.Constants;
 import io.qameta.allure.core.LaunchResults;
@@ -65,7 +66,7 @@ public class HistoryTrendPlugin extends AbstractTrendPlugin<HistoryTrendItem> {
         final List<HistoryTrendItem> data = getHistoryItems(launchesResults);
 
         return Stream.concat(Stream.of(item), data.stream())
-                .limit(20)
+                .limit(Aggregator.resultsLimit())
                 .collect(Collectors.toList());
     }
 

--- a/allure-generator/src/main/java/io/qameta/allure/retry/RetryTrendPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/retry/RetryTrendPlugin.java
@@ -18,6 +18,7 @@ package io.qameta.allure.retry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Aggregator;
 import io.qameta.allure.CommonJsonAggregator;
 import io.qameta.allure.Constants;
 import io.qameta.allure.core.LaunchResults;
@@ -55,7 +56,7 @@ public class RetryTrendPlugin extends AbstractTrendPlugin<RetryTrendItem> {
         final List<RetryTrendItem> data = getHistoryItems(launchesResults);
 
         return Stream.concat(Stream.of(item), data.stream())
-                .limit(20)
+                .limit(Aggregator.resultsLimit())
                 .collect(Collectors.toList());
     }
 

--- a/allure-plugin-api/src/main/java/io/qameta/allure/Aggregator.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/Aggregator.java
@@ -21,6 +21,7 @@ import io.qameta.allure.core.LaunchResults;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Aggregator extension. Can be used to process results and/or generate
@@ -30,6 +31,17 @@ import java.util.List;
  */
 @FunctionalInterface
 public interface Aggregator extends Extension {
+
+    /**
+     * Configure the number of items to be rendered on different charts.
+     *
+     * @return RESULTS_LIMIT provided by user, or a default value = 20.
+     */
+    static long resultsLimit() {
+        return Optional.ofNullable(System.getenv("ALLURE_RESULTS_LIMIT"))
+                .map(Long::parseLong)
+                .orElse(20L);
+    }
 
     /**
      * Process report data.


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
There were several places in code with hardcoded limits for items rendered on charts. It was really inconvenient for the end-user who had to rebuild the entire project to make limits configurable.

This fix moves the actual configuration into an Aggregator interface which is implemented by key plugins. Moreover, a user can now control the limits via `ALLURE_RESULTS_LIMIT` env variable that could be set before the report's generation. Note that a newly added method was intentionally made static as some of the APIs that adjust the limits are also static.

Fixes #347

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
