### PR TITLE
Switch to * so generated classpath is not too long for Windows

### DIFF
--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -42,7 +42,7 @@ val main = sourceSets.getByName("main")
 
 val startScripts by tasks.existing(CreateStartScripts::class) {
     applicationName = "allure"
-    classpath = classpath?.plus(files("src/lib/config"))
+    classpath = files("src/lib/*", "src/lib/config")
     doLast {
         unixScript.writeText(unixScript.readText()
                 .replace(Regex("(?m)^APP_HOME="), "export APP_HOME=")


### PR DESCRIPTION
### Context
Carl Bray
Changed classpath generation to use a wildcard * so paths aren't too long on Windows (fixes #1501\)

As a special convenience, a class path element that contains a base name of * is considered equivalent to specifying a list of all the files in the directory with the extension .jar or .JAR https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html

#### Checklist
- [X] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
