### PR TITLE
Show error message & trace in steps

### DIFF
--- a/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
+++ b/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
@@ -18,7 +18,7 @@
                 {{> ../../blocks/attachment-row/attachment-row . baseUrl=../../baseUrl}}
             {{/each}}
             {{#if shouldDisplayMessage}}
-                {{~> ../../blocks/status-details/status-details . status=../status}}
+                {{~> ../../blocks/status-details/status-details .}}
             {{/if}}
         </div>
     </div>

--- a/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
+++ b/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
@@ -18,9 +18,7 @@
                 {{> ../../blocks/attachment-row/attachment-row . baseUrl=../../baseUrl}}
             {{/each}}
             {{#if shouldDisplayMessage}}
-                {{#with statusDetails}}
-                    {{~> ../../blocks/status-details/status-details . status=../status}}
-                {{/with}}
+                {{~> ../../blocks/status-details/status-details . status=../status}}
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
fixes #774

### Issue
Error message and trace is not displayed for steps

<img width="1536" alt="Before Fix" src="https://user-images.githubusercontent.com/29650842/150583093-b944e5b4-dd5c-4cb2-bfdc-ee9a2bfd4ef8.png">

### Cause
Due to this commit https://github.com/allure-framework/allure2/commit/bdf05a88f92746a71c2f16a5f44edad5ecd018f2 in which `StatusDetails` was removed 

### Fix
Remove `statusDetails` reference in the template file

<img width="1536" alt="After Fix" src="https://user-images.githubusercontent.com/29650842/150583331-9b8cdb58-b494-4ab1-8f2f-a8748b5d1b29.png">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
