### PR TITLE
Introduced search by tags in html report

### DIFF
--- a/allure-generator/src/main/javascript/components/tree/TreeView.js
+++ b/allure-generator/src/main/javascript/components/tree/TreeView.js
@@ -1,7 +1,7 @@
 import "./styles.scss";
 import { View } from "backbone.marionette";
 import getComparator from "../../data/tree/comparator";
-import { byMark, byStatuses, byText, mix } from "../../data/tree/filter";
+import { byCriteria, byMark, byStatuses, mix } from "../../data/tree/filter";
 import { behavior, className, on } from "../../decorators";
 import router from "../../router";
 import hotkeys from "../../utils/hotkeys";
@@ -37,7 +37,7 @@ class TreeView extends View {
     const visibleStatuses = this.settings.getVisibleStatuses();
     const visibleMarks = this.settings.getVisibleMarks();
     const searchQuery = this.state.get(SEARCH_QUERY_KEY);
-    const filter = mix(byText(searchQuery), byStatuses(visibleStatuses), byMark(visibleMarks));
+    const filter = mix(byCriteria(searchQuery), byStatuses(visibleStatuses), byMark(visibleMarks));
 
     const sortSettings = this.settings.getTreeSorting();
     const sorter = getComparator(sortSettings);

--- a/allure-generator/src/main/javascript/data/tree/filter.js
+++ b/allure-generator/src/main/javascript/data/tree/filter.js
@@ -18,6 +18,14 @@ function byDuration(min, max) {
   };
 }
 
+function byCriteria(searchQuery) {
+  if (searchQuery && searchQuery.startsWith("tag:")) {
+    return byTags(searchQuery.substring(4));
+  } else {
+    return byText(searchQuery);
+  }
+}
+
 function byText(text) {
   text = (text && text.toLowerCase()) || "";
   return (child) => {
@@ -25,6 +33,18 @@ function byText(text) {
       !text ||
       child.name.toLowerCase().indexOf(text) > -1 ||
       (child.children && child.children.some(byText(text)))
+    );
+  };
+}
+
+function byTags(tag) {
+  tag = (tag && tag.toLowerCase().trim()) || "";
+  const tags = tag.split(/\s*,\s*/).filter((t) => t);
+  return (child) => {
+    return (
+      !tag ||
+      (Array.isArray(child.tags) && tags.every((t) => child.tags.indexOf(t) > -1)) ||
+      (child.children && child.children.some(byTags(tag)))
     );
   };
 }
@@ -50,4 +70,4 @@ function mix(...filters) {
   };
 }
 
-export { byStatuses, byDuration, byText, byMark, mix };
+export { byStatuses, byDuration, byCriteria, byText, byTags, byMark, mix };

--- a/allure-plugin-api/src/main/java/io/qameta/allure/tree/TestResultTreeLeaf.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/tree/TestResultTreeLeaf.java
@@ -20,6 +20,7 @@ import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.entity.Time;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -38,6 +39,7 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
     private final boolean retriesStatusChange;
 
     private final List<String> parameters;
+    private final Set<String> tags;
 
     public TestResultTreeLeaf(final String parentUid, final TestResult testResult) {
         this(
@@ -60,6 +62,7 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
         this.retriesStatusChange = testResult.isRetriesStatusChange();
         this.retriesCount = testResult.getRetriesCount();
         this.parameters = testResult.getParameterValues();
+        this.tags = testResult.getExtraBlock("tags");
     }
     public String getParentUid() {
         return parentUid;
@@ -103,5 +106,9 @@ public class TestResultTreeLeaf extends DefaultTreeLeaf {
 
     public List<String> getParameters() {
         return parameters;
+    }
+
+    public Set<String> getTags() {
+        return tags;
     }
 }


### PR DESCRIPTION
Introduced search by tags in html report.
Use "tag:" prefix for search by tags (as commma-separated list). E.g. type in search field: "tag:tag1,tag2".
File suites.json is enhanced by "tags" field.