### PR TITLE
Catch AWTError if X11 is used and DISPLAY is unavailable

### DIFF
--- a/allure-commandline/src/main/java/io/qameta/allure/Commands.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/Commands.java
@@ -20,6 +20,7 @@ import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.Plugin;
 import io.qameta.allure.option.ConfigOptions;
 import io.qameta.allure.plugin.DefaultPluginLoader;
+import java.awt.AWTError;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -149,7 +150,7 @@ public class Commands {
 
         try {
             openBrowser(server.getURI());
-        } catch (IOException e) {
+        } catch (IOException | AWTError e) {
             LOGGER.error(
                     "Could not open the report in browser, try to open it manually {}: {}",
                     server.getURI(),


### PR DESCRIPTION
### Context
If one uses X11 and tries to open a report in a terminal session with invalid DISPLAY env variable, he gets "Can't connect to X11 window server" error in `isDesktopSupported()` method, and this exception is uncaught now. This PR fixes it.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
