### PR TITLE
Map JUnit XML test case `<properties>` to test result parameters

### DIFF
--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -22,6 +22,7 @@ import io.qameta.allure.core.ResultsVisitor;
 import io.qameta.allure.entity.Attachment;
 import io.qameta.allure.entity.Label;
 import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.entity.Parameter;
 import io.qameta.allure.entity.StageResult;
 import io.qameta.allure.entity.Status;
 import io.qameta.allure.entity.TestResult;
@@ -310,6 +311,25 @@ class JunitXmlPluginTest {
                 .describedAs("Should parse skipped elements and status attribute")
                 .hasSize(2);
 
+    }
+
+    @Test
+    void shouldUsePropertiesIfPresent() throws Exception {
+        process(
+                "junitdata/TEST-test.PropertiesTest.xml", "TEST-test.SampleTest.xml"
+        );
+
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
+        verify(visitor, times(2)).visitTestResult(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("foo", "bar"),
+                        tuple("baz", "some value")
+                );
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.PropertiesTest.xml
+++ b/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.PropertiesTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite tests="1" failures="0" name="test.SampleTest" time="1.051" errors="0" skipped="0">
+  <testcase classname="test.PropertiesTest" name="shouldGenerate" time="1.051">
+    <properties>
+      <property name="foo" value="bar" />
+      <property name="baz" value="some value" />
+    </properties>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
### Context
This makes a test case's `<properties><property name="foo" value="bar" /></properties>`  element in the Junit XML file show up as test case parameters in the report.

#### Checklist
- [X] [Sign Allure CLA][cla]
- [X] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
