### PR TITLE
Take nested attachments into account when doing the screenshots diff

### DIFF
--- a/plugins/screen-diff-plugin/src/dist/static/index.js
+++ b/plugins/screen-diff-plugin/src/dist/static/index.js
@@ -12,8 +12,37 @@
     }
 
     function findImage(data, name) {
-        if (data.testStage && data.testStage.attachments) {
-            var matchedImage = data.testStage.attachments.filter(function (attachment) {
+        // Gather all attachments across stages
+        allAttachments = [];
+
+        // Go through attachments from the test stage
+        if (data.testStage) {
+            if (data.testStage.attachments) {
+                allAttachments.push(...data.testStage.attachments);
+            }
+
+            if (data.testStage.steps) {
+                for (const step of data.testStage.steps) {
+                    if (step.attachments) {
+                        allAttachments.push(...step.attachments)
+                    }
+                }
+            }
+        }
+
+        // Go through attachments from the before- and after-test stages
+        for (const stages of [data.beforeStages, data.afterStages]) {
+            if (stages) {
+                for (const stage of data.afterStages) {
+                    if (stage.attachments) {
+                        allAttachments.push(...stage.attachments)
+                    }
+                }
+            }
+        }
+        
+        if (allAttachments.length > 0) {
+            var matchedImage = allAttachments.filter(function (attachment) {
                 return attachment.name === name;
             })[0];
             if (matchedImage) {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The screen-diff plugin works great but it doesn't take into account attachments that are nested in an Allure step, or that are attached to the before-/after-test stages. This PR extends the `findImage` function of the plugin to take all the steps/stages into account.

I tested it locally, as can be seen on the following screenshot (black boxes hide private information, red lines highlighting the change):
![allure-screenshot](https://user-images.githubusercontent.com/6297260/208954770-23b12aa7-834a-4c07-abad-0ccfd0aa22a7.jpg)


#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests: not sure how to add them, as I didn't find tests for this plugin

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
