### PR TITLE
Fix the layout of step stats

### DIFF
--- a/allure-generator/src/main/javascript/components/testresult-execution/styles.scss
+++ b/allure-generator/src/main/javascript/components/testresult-execution/styles.scss
@@ -10,6 +10,9 @@
 }
 
 .step {
+  &__name {
+    display: inline-flex;
+  }
   line-height: 1.2em;
   &__status {
     left: 7px;

--- a/allure-generator/src/main/javascript/helpers/text-with-links.js
+++ b/allure-generator/src/main/javascript/helpers/text-with-links.js
@@ -12,7 +12,7 @@ export default function(text) {
         encodeHTMLEntities(text).replace(
           URL_REGEXP,
           (_, urlFullText, urlProtocol, terminalSymbol) => {
-            return ` <a class="link" target="_blank" href="${
+            return `&nbsp;<a class="link" target="_blank" href="${
               urlProtocol ? urlFullText : `https://${urlFullText}`
             }">${urlFullText}</a>${terminalSymbol} `;
           },


### PR DESCRIPTION
Layout correction of steps stats (fixes #1992)

After fixing when hovering over a link:
![image](https://github.com/allure-framework/allure2/assets/43988977/cc798f65-c741-4fb7-b6af-5d341222a85c)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
