### PR TITLE
Fix disable analytics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         run: echo "::set-output name=version::${GITHUB_REF:10}"
       - uses: actions/checkout@v3.5.3
 
-      - name: "Set up JDK 1.8"
+      - name: "Set up JDK"
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/allure-generator/src/main/resources/tpl/index.html.ftl
+++ b/allure-generator/src/main/resources/tpl/index.html.ftl
@@ -25,12 +25,16 @@
     <script src="plugins/${plugin.id}/${jsFile}"></script>
     </#list>
 </#list>
+<#if ALLURE_NO_ANALYTICS == false>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-FVWC4GKEYS"></script>
+</#if>
 <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'G-FVWC4GKEYS');
+    gtag('allureVersion', '${allureVersion}')
+    gtag('reportUuid', '${reportUuid}')
 </script>
 </body>
 </html>

--- a/allure-plugin-api/src/main/java/io/qameta/allure/Constants.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/Constants.java
@@ -47,6 +47,11 @@ public final class Constants {
      */
     public static final String HISTORY_DIR = "history";
 
+    /**
+     * The name of environment variable that disables analytics.
+     */
+    public static final String NO_ANALYTICS = "ALLURE_NO_ANALYTICS";
+
     private Constants() {
         throw new IllegalStateException("Do not instance");
     }

--- a/allure-plugin-api/src/main/java/io/qameta/allure/ReportInfo.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/ReportInfo.java
@@ -13,32 +13,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.ga;
+package io.qameta.allure;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
+
 /**
- * Parameters for {@link GaPlugin}.
- *
- * @author eroshnkoam
+ * @author charlie (Dmitry Baev).
  */
 @Data
 @Accessors(chain = true)
-public class GaParameters {
+public class ReportInfo implements Serializable {
 
-    private String reportUuid;
+    private static final long serialVersionUID = 1L;
 
     private String allureVersion;
-
-    private String executorType;
-
-    private String language;
-
-    private String framework;
-
-    private long resultsCount;
-
-    private String resultsFormat;
+    private String reportUuid;
 
 }

--- a/allure-plugin-api/src/main/java/io/qameta/allure/context/ReportInfoContext.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/context/ReportInfoContext.java
@@ -13,32 +13,28 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.ga;
+package io.qameta.allure.context;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
+import io.qameta.allure.Context;
+import io.qameta.allure.ReportInfo;
+
+import java.util.UUID;
 
 /**
- * Parameters for {@link GaPlugin}.
- *
- * @author eroshnkoam
+ * @author charlie (Dmitry Baev).
  */
-@Data
-@Accessors(chain = true)
-public class GaParameters {
+public class ReportInfoContext implements Context<ReportInfo> {
 
-    private String reportUuid;
+    private final ReportInfo reportInfo;
 
-    private String allureVersion;
+    public ReportInfoContext(final String allureVersion) {
+        this.reportInfo = new ReportInfo()
+                .setAllureVersion(allureVersion)
+                .setReportUuid(UUID.randomUUID().toString());
+    }
 
-    private String executorType;
-
-    private String language;
-
-    private String framework;
-
-    private long resultsCount;
-
-    private String resultsFormat;
-
+    @Override
+    public ReportInfo getValue() {
+        return reportInfo;
+    }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The latest changes in the report don't allow for turning off Google Analytics. This PR fixes it. Now people can use `ALLURE_NO_ANALYTICS` env variable during report generation to completely disable analytics for report users.

fixes #2014

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] ~Provide unit tests~

[cla]: https://cla-assistant.io/accept/allure-framework/allure2