### PR TITLE
Remove leading whitespace before URL wrapped as link

### DIFF
--- a/allure-generator/src/main/javascript/helpers/text-with-links.js
+++ b/allure-generator/src/main/javascript/helpers/text-with-links.js
@@ -12,7 +12,7 @@ export default function(text) {
         encodeHTMLEntities(text).replace(
           URL_REGEXP,
           (_, urlFullText, urlProtocol, terminalSymbol) => {
-            return `&nbsp;<a class="link" target="_blank" href="${
+            return `<a class="link" target="_blank" href="${
               urlProtocol ? urlFullText : `https://${urlFullText}`
             }">${urlFullText}</a>${terminalSymbol} `;
           },


### PR DESCRIPTION
Leading whitespaces before URLs wrapped as links confuse users:
<img width="822" alt="whitespace" src="https://github.com/allure-framework/allure2/assets/5081226/269668a9-23ae-401d-a31d-74ecd1a189de">

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
