### PR TITLE
Add support for attachment meta steps

### DIFF
--- a/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
+++ b/allure-generator/src/main/javascript/components/testresult-execution/steps-list.hbs
@@ -1,23 +1,29 @@
 {{#each steps}}
     <div class="step">
+        {{#if attachmentStep}}
+        {{#each attachments}}
+          {{> ../../blocks/attachment-row/attachment-row . baseUrl=../../baseUrl}}
+        {{/each}}
+        {{else}}
         <div class="{{b "step" "title" hasContent=hasContent}} long-line">
-            {{#if hasContent}}
-                <span class="step__arrow block__arrow">{{arrow status}}</span>
-            {{else}}
-                <span class="step__status">{{allure-icon status}}</span>
-            {{/if}}
-            <div class="step__name">{{text-with-links name}}</div>
-            {{> ../../blocks/step-stats/step-stats . baseUrl=../../baseUrl}}
+          {{#if hasContent}}
+            <span class="step__arrow block__arrow">{{arrow status}}</span>
+          {{else}}
+            <span class="step__status">{{allure-icon status}}</span>
+          {{/if}}
+          <div class="step__name">{{text-with-links name}}</div>
+          {{> ../../blocks/step-stats/step-stats . baseUrl=../../baseUrl}}
         </div>
         <div class="step__content">
-            {{> ../../blocks/parameters-table/parameters-table parameters=parameters }}
-            {{~> steps-list steps=steps baseUrl=../baseUrl}}
-            {{#each attachments}}
-                {{> ../../blocks/attachment-row/attachment-row . baseUrl=../../baseUrl}}
-            {{/each}}
-            {{#if shouldDisplayMessage}}
-                {{~> ../../blocks/status-details/status-details .}}
-            {{/if}}
+          {{> ../../blocks/parameters-table/parameters-table parameters=parameters }}
+          {{~> steps-list steps=steps baseUrl=../baseUrl}}
+          {{#each attachments}}
+            {{> ../../blocks/attachment-row/attachment-row . baseUrl=../../baseUrl}}
+          {{/each}}
+          {{#if shouldDisplayMessage}}
+            {{~> ../../blocks/status-details/status-details .}}
+          {{/if}}
         </div>
+        {{/if}}
     </div>
 {{/each}}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/Summarizable.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/Summarizable.java
@@ -29,6 +29,8 @@ import static java.util.Objects.isNull;
  */
 public interface Summarizable {
 
+    String getName();
+
     String getStatusMessage();
 
     List<Step> getSteps();
@@ -76,5 +78,12 @@ public interface Summarizable {
         final List<Step> steps = isNull(getSteps()) ? emptyList() : getSteps();
         final List<Parameter> parameters = isNull(getParameters()) ? emptyList() : getParameters();
         return steps.size() + attachments.size() + parameters.size() > 0 || shouldDisplayMessage();
+    }
+
+    @JsonProperty
+    default boolean isAttachmentStep() {
+        return getStepsCount() == 0
+               && getAttachmentsCount() == 1
+               && Objects.equals(getName(), getAttachments().get(0).getName());
     }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Due to limitations of the Allure 2 Model, attachments are always rendered at the end of the execution item. For example, the following code 

```ts
await allure.logStep("step 1");
await allure.attachment("some data", "content", "text/plain");
await allure.logStep("step 2");
```

will show in the report:

1. step 1
2. step 2
3. some data

To workaround the issue, users may wrap attachments in steps, e.g. by adding `@Step` annotation on top of `@Attachment` method. However, such an approach will create *redundant* steps in the report. This pull request is fixing that, removing an extra step from the report.


<img width="770" alt="Screenshot 2023-09-11 at 15 05 58" src="https://github.com/allure-framework/allure2/assets/2149631/639f9d2c-69e8-4a34-8d80-2e2dc832f3ff">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2