### PR TITLE
CVE-2023-36478: Update jetty-server to 9.4.53.v20231009

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ subprojects {
             dependency("org.apache.httpcomponents:httpclient:4.5.14")
             dependency("org.apache.tika:tika-core:2.9.0")
             dependency("org.assertj:assertj-core:3.24.2")
-            dependency("org.eclipse.jetty:jetty-server:9.4.51.v20230217")
+            dependency("org.eclipse.jetty:jetty-server:9.4.53.v20231009")
             dependency("org.freemarker:freemarker:2.3.32")
             dependency("org.junit-pioneer:junit-pioneer:2.1.0")
             dependency("org.mockito:mockito-core:5.6.0")


### PR DESCRIPTION
To address CVE-2023-36478 which is a high-severity vulnerability, easily resolved with a jetty-server update.

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
