### PR TITLE
Fix plugins not showing up in Single Html mode

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/core/ReportWebGenerator.java
+++ b/allure-generator/src/main/java/io/qameta/allure/core/ReportWebGenerator.java
@@ -34,6 +34,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,7 +60,7 @@ public class ReportWebGenerator {
 
         final boolean inline = reportStorage instanceof InMemoryReportStorage;
 
-        final Set<String> jsFiles = new HashSet<>();
+        final LinkedHashSet<String> jsFiles = new LinkedHashSet<>();
         if (inline) {
             jsFiles.add(dataBase64(TEXT_JAVASCRIPT, APP_JS));
         } else {


### PR DESCRIPTION
### Context
Fix #2194

**Root cause:**
We're using `Set<String> jsFiles`. The Set interface does not provide any ordering guarantees. We should make sure `APP_JS` at the top of other scripts.

**Solution:**
Use `LinkedHashSet` instead to guarantee the js scripts ordering.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
