### PR TITLE
Interslavic translation

### DIFF
--- a/allure-generator/src/main/javascript/translations/isv.json
+++ b/allure-generator/src/main/javascript/translations/isv.json
@@ -1,0 +1,208 @@
+{
+  "chart": {
+    "duration": {
+      "empty": "Nema informacije",
+      "name": "Trvanje testov"
+    },
+    "severity": {
+      "name": "Važnost testov"
+    },
+    "status": {
+      "name": "Statusy testov"
+    },
+    "trend": {
+      "empty": "Nema informacije"
+    }
+  },
+  "component": {
+    "markToggle": {
+      "hideCases": "Skryj rezultaty označene kako \"{{mark}}\"",
+      "showCases": "Pokaži rezultaty označene kako \"{{mark}}\""
+    },
+    "statusToggle": {
+      "hideCases": "Skryj rezultaty so statusom \"{{status}}\"",
+      "showCases": "Pokaži rezultaty so statusom \"{{status}}\""
+    },
+    "tree": {
+      "download": "Daunloduj CSV",
+      "empty": "Nema informacije",
+      "filter": "Statusy",
+      "filter-marks": "Označenja",
+      "filtered": {
+        "shown_0": "{{count}} pokazany",
+        "shown_1": "{{count}} pokazane",
+        "shown_2": "{{count}} pokazane",
+        "total_0": "{{count}} test vsěgo",
+        "total_1": "{{count}} testy vsěgo",
+        "total_2": "{{count}} testov vsěgo"
+      },
+      "groups": "Pokaži informaciju o grupah",
+      "time": {
+        "max": {
+          "name": "Najvyše dolgy",
+          "tooltip": "Koliko časa trval najvyše dolgy test v grupě"
+        },
+        "sum": {
+          "name": "V sumě",
+          "tooltip": "Suma trvanij vsih testov v grupě"
+        },
+        "total": {
+          "name": "Cělo",
+          "tooltip": "Čas od početka prvogo testa do konca poslědnogo"
+        }
+      },
+      "unknown": "<Nema>"
+    },
+    "widgetStatus": {
+      "showAll": "Pokaži vsečto",
+      "total_0": "{{count}} element vsěgo",
+      "total_1": "{{count}} elementa vsěgo",
+      "total_2": "{{count}} elementov vsěgo"
+    }
+  },
+  "controls": {
+    "backto": "Vzad do",
+    "clipboard": "Kopiruj do klipborda",
+    "clipboardError": "Pogrěška. Věrojetno, vaša prěgledka (brauzer) ne podpira kopirovanje do klipborda.",
+    "clipboardSuccess": "Tekst byl skopirovany",
+    "collapse": "Minimizuj",
+    "expand": "Razširi",
+    "fullscreen": "Na cěly ekran",
+    "language": "Izměni jezyk"
+  },
+  "errors": {
+    "missedAttachment": "Priloga ne najdena",
+    "notFound": "Ne najdeno"
+  },
+  "marks": {
+    "flaky": "Nestabilny",
+    "newBroken": "Iznova slomjeny",
+    "newFailed": "Iznova neuspěšny",
+    "newPassed": "Iznova uspěšny",
+    "retriesStatusChange": "Status měnjal se od proby do proby"
+  },
+  "sorter": {
+    "duration": "trvanje",
+    "name": "nazva",
+    "order": "poredok",
+    "status": "status"
+  },
+  "status": {
+    "broken": "Slomjeny",
+    "failed": "Neuspěšny",
+    "passed": "Uspěšny",
+    "skipped": "Propuščeny",
+    "unknown": "Neznany"
+  },
+  "tab": {
+    "categories": {
+      "name": "Kategorije"
+    },
+    "graph": {
+      "name": "Diagramy"
+    },
+    "overview": {
+      "name": "Prěgled"
+    },
+    "suites": {
+      "name": "Komplety testov"
+    },
+    "timeline": {
+      "name": "Hronologija",
+      "selected_0": "Izbrany {{count}} test ({{percent}}%) s trvanjem vyše od {{duration}}",
+      "selected_1": "Izbrane {{count}} testy ({{percent}}%) s trvanjem vyše od {{duration}}",
+      "selected_2": "Izbrane {{count}} testov ({{percent}}%) s trvanjem vyše od {{duration}}"
+    }
+  },
+  "testResult": {
+    "categories": {
+      "name": "Kategorije"
+    },
+    "description": {
+      "name": "Opis"
+    },
+    "duration": {
+      "name": "Trvanje"
+    },
+    "execution": {
+      "body": "Tělo testa",
+      "name": "Izpolnjenje",
+      "setup": "Prigotovjenje",
+      "teardown": "Zaključenje"
+    },
+    "history": {
+      "name": "Historija",
+      "successRate": "Procent uspěha"
+    },
+    "links": {
+      "name": "Linky"
+    },
+    "overview": {
+      "name": "Prěgled"
+    },
+    "owner": {
+      "name": "Vlastnik"
+    },
+    "parameters": {
+      "name": "Parametry"
+    },
+    "retries": {
+      "empty": "Nema informacije o minulyh probah testa",
+      "name": "Minule proby"
+    },
+    "severity": {
+      "name": "Važnost"
+    },
+    "stats": {
+      "count": {
+        "attachments_0": "{{count}} priloga",
+        "attachments_1": "{{count}} prilogy",
+        "attachments_2": "{{count}} prilog",
+        "parameters_0": "{{count}} parametr",
+        "parameters_1": "{{count}} parametry",
+        "parameters_2": "{{count}} parametrov",
+        "steps_0": "{{count}} vloženy krok",
+        "steps_1": "{{count}} vložene kroky",
+        "steps_2": "{{count}} vloženyh krokov"
+      }
+    },
+    "status": {
+      "empty": "Nema dodatnoj informacije o statusu",
+      "trace": "Pokaži dodatnu informaciju"
+    }
+  },
+  "widget": {
+    "categories": {
+      "name": "Kategorije"
+    },
+    "environment": {
+      "empty": "Nema informacije o obsrědině",
+      "name": "Obsrědina",
+      "showAll": "Pokaži vsečto"
+    },
+    "executors": {
+      "empty": "Nema informacije o izpolniteljah",
+      "name": "Sistemy izpolnjenja testov",
+      "unknown": "Neznano"
+    },
+    "launches": {
+      "empty": "Nema informacije o puščenjah",
+      "name": "Puščenja testov"
+    },
+    "suites": {
+      "name": "Komplety testov"
+    },
+    "summary": {
+      "aggregatedName": "Agregovany raport",
+      "launches_0": "puščenje testov",
+      "launches_1": "puščenja testov",
+      "launches_2": "puščenij testov",
+      "testResults_0": "testovy scenarij",
+      "testResults_1": "testove scenarije",
+      "testResults_2": "testovyh scenarijev"
+    },
+    "trend": {
+      "name": "Trend"
+    }
+  }
+}

--- a/allure-generator/src/main/javascript/utils/translation.js
+++ b/allure-generator/src/main/javascript/utils/translation.js
@@ -17,6 +17,7 @@ export const LANGUAGES = [
   { id: "fr", title: "Français" },
   { id: "az", title: "Azərbaycanca" },
   { id: "tr", title: "Türkçe" },
+  { id: "isv", abbr: "Ⱄ", title: "Medžuslovjansky" },
 ];
 
 LANGUAGES.map((lang) => lang.id).forEach((lang) =>
@@ -36,6 +37,12 @@ export function initTranslations() {
       },
       (err) => (err ? reject(err) : resolve()),
     );
+
+    i18next.on("initialized", () => {
+      const pluralResolver = i18next.services.pluralResolver;
+      pluralResolver.addRule("isv", pluralResolver.getRule("be"));
+    });
+
     gtag("init_language", { language: language || "en" });
   });
 }

--- a/plugins/behaviors-plugin/src/dist/static/index.js
+++ b/plugins/behaviors-plugin/src/dist/static/index.js
@@ -182,6 +182,20 @@ allure.api.addTranslation('az', {
     }
 });
 
+allure.api.addTranslation('isv', {
+    tab: {
+        behaviors: {
+            name: 'Funkcionalnost',
+        }
+    },
+    widget: {
+        behaviors: {
+            name: 'Funkcionalnost',
+            showAll: 'pokaži vsěčto',
+        }
+    }
+});
+
 allure.api.addTab('behaviors', {
     title: 'tab.behaviors.name', icon: 'fa fa-list',
     route: 'behaviors(/)(:testGroup)(/)(:testResult)(/)(:testResultTab)(/)',

--- a/plugins/packages-plugin/src/dist/static/index.js
+++ b/plugins/packages-plugin/src/dist/static/index.js
@@ -104,6 +104,14 @@ allure.api.addTranslation('az', {
     }
 });
 
+allure.api.addTranslation('isv', {
+    tab: {
+        packages: {
+            name: 'Pakety'
+        }
+    }
+});
+
 allure.api.addTab('packages', {
     title: 'tab.packages.name', icon: 'fa fa-align-left',
     route: 'packages(/)(:testGroup)(/)(:testResult)(/)(:testResultTab)(/)',


### PR DESCRIPTION
### Context

Hello! At the Interslavic OSS organization, we aim to cover morphological and orthographical functionality (word inflection, verb conjugation, transliteration, etc.) with unit tests, and while English is a good choice for keeping technical documentation, it is preferable to make reports accessible for every contributor to Interslavic language:

[![isv-utils-allure-121 surge sh_](https://github.com/allure-framework/allure2/assets/1962469/1fb168e1-f4a4-4c09-83b3-59e69a1d16a9)](https://isv-utils-allure-121.surge.sh/#suites/53f85243d11e11c923a9fbdc09a8f2ac/f86c8f82733cd319/)

#### New translation

| Dashboard |  Test page |
|-|-|
|![dashboard](https://github.com/allure-framework/allure2/assets/1962469/b8c63d27-5efa-4aae-9dd0-d7a7fe9a3e6d)|![test_page](https://github.com/allure-framework/allure2/assets/1962469/df2cf945-9544-4785-8fb6-77fe06f51cf9)|

#### Developer notes

1. Since Interslavic is not supported by i18next directly, I had to copy&paste suitable pluralization rules (1,2,5):

```js
i18next.on("initialized", () => {
  const pluralResolver = i18next.services.pluralResolver;
  pluralResolver.addRule("isv", pluralResolver.getRule("be"));
});
```

2. The last contributor who submitted Turkish translation accidently converted some of files to CRLF. My pull request brings LF endings back. Please use the ["Hide whitespace"](https://github.com/allure-framework/allure2/pull/2373/files?diff=split&w=1) option on GitHub when reviewing.

3. The language code used ("isv") is not official yet, although our pending ISO committee submissions for code pretend exactly for this one. I could have used "art-x-interslv" (current idiomatic BCP 47 identifier according to [CLCR](https://www.kreativekorp.com/clcr/)), but that would require extra changes to your Handlebars template rendering – e.g., to introduce some `language.abbr` property along with `language.id` to avoid breaking the language selector visually.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests
  Not sure if this is applicable here – there are no IF-ELSE branches in my i18next plural augmentation code, and the API I'm using is stable enough – it is still available both in `i18next@8` and in `i18next@23`, so I don't see major reasons to worry. 🤷‍♂️ 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2

P.S. @ru-danko, thanks for checking on the translation keys.