### PR TITLE
Refactor Category and Severity JS views

### DIFF
--- a/allure-generator/src/main/javascript/plugins/testresult-category/CategoryView.js
+++ b/allure-generator/src/main/javascript/plugins/testresult-category/CategoryView.js
@@ -3,7 +3,7 @@ import { className } from "../../decorators/index";
 import template from "./CategoryView.hbs";
 
 @className("pane__section")
-class SeverityView extends View {
+class CategoryView extends View {
   template = template;
 
   serializeData() {
@@ -14,4 +14,4 @@ class SeverityView extends View {
   }
 }
 
-export default SeverityView;
+export default CategoryView;

--- a/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.hbs
@@ -1,0 +1,4 @@
+{{#if severity}}
+    {{t 'testResult.severity.name'}}:
+    {{t (concat 'testResult.severity.' severity)}}
+{{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.js
+++ b/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.js
@@ -1,14 +1,10 @@
 import { View } from "backbone.marionette";
-import { className } from "../../decorators/index";
-import translate from "../../helpers/t";
+import { className } from "../../decorators";
+import template from "./SeverityView.hbs";
 
 @className("pane__section")
 class SeverityView extends View {
-  template({ severity }) {
-    return severity
-      ? `${translate("testResult.severity.name")}: ${translate(`testResult.severity.${severity}`)}`
-      : "";
-  }
+  template = template;
 
   serializeData() {
     const extra = this.model.get("extra");


### PR DESCRIPTION
### Context

While working with `allure-generator`'s codebase, I noticed two inconsistencies:

1. `CategoryView` had a misleading name (apparently, that occurred while copying and pasting).
2. `SeverityView` is the only one without a Handlebars template, so I extracted the rendering logic to `SeverityView.hbs`

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] ~Provide unit tests~ (not applicable, but I verified manually my change anyway)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
