### PR TITLE
Make test result labels more stylable

### DIFF
--- a/allure-generator/src/main/javascript/blocks/pane/styles.scss
+++ b/allure-generator/src/main/javascript/blocks/pane/styles.scss
@@ -48,5 +48,11 @@
 
   &__section-title {
     margin: 0 0 $gap-size;
+
+    @at-root #{selector-append('span', &)} {
+      &::after {
+        content: ':';
+      }
+    }
   }
 }

--- a/allure-generator/src/main/javascript/plugins/testresult-category/CategoryView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-category/CategoryView.hbs
@@ -1,6 +1,8 @@
 {{#if categories}}
-    {{t 'testResult.categories.name'}}:
-    {{#each categories}}
-        <span>{{name}} </span>
-    {{/each}}
+    <span class="pane__section-title">{{t 'testResult.categories.name'}}</span>
+    <span class="pane__section-content">
+        {{#each categories}}
+            <span>{{name}} </span>
+        {{/each}}
+    </span>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-description/DescriptionView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-description/DescriptionView.hbs
@@ -1,4 +1,4 @@
 {{#if descriptionHtml}}
     <h3 class="pane__section-title">{{t 'testResult.description.name'}}</h3>
-    <div class="description__text">{{{descriptionHtml}}}</div>
+    <div class="pane__section-content description__text">{{{descriptionHtml}}}</div>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-duration/DurationView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-duration/DurationView.hbs
@@ -1,7 +1,9 @@
 {{#if time}}
-    <span data-tooltip="{{date time.start}} {{time time.start}}&nbsp;&ndash;&nbsp;{{time time.stop}}">
-        {{t 'testResult.duration.name'}}:
-        <span class="fa fa-clock-o"></span>
-        {{duration time.duration 2}}
-    </span>
+    <div data-tooltip="{{date time.start}} {{time time.start}}&nbsp;&ndash;&nbsp;{{time time.stop}}">
+        <span class="pane__section-title">{{t 'testResult.duration.name'}}</span>
+        <span class="pane__section-content">
+            <span class="fa fa-clock-o"></span>
+            {{duration time.duration 2}}
+        </span>
+    </div>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-links/LinksView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-links/LinksView.hbs
@@ -1,14 +1,16 @@
 {{#if links}}
     <h3 class="pane__section-title">{{t 'testResult.links.name'}}</h3>
-    {{#each links}}
-        <span class="testresult-link">
-        {{#if (eq type "issue")}}
-            <span class="fa fa-bug"></span>
-        {{/if}}
-        {{#if (eq type "tms")}}
-            <span class="fa fa-database"></span>
-        {{/if}}
-        <a class="link" href="{{default url name}}" target="_blank">{{default name url 'link'}}</a>
-    </span>
-    {{/each}}
+    <div class="pane__section-content">
+        {{#each links}}
+            <span class="testresult-link">
+            {{#if (eq type "issue")}}
+                <span class="fa fa-bug"></span>
+            {{/if}}
+            {{#if (eq type "tms")}}
+                <span class="fa fa-database"></span>
+            {{/if}}
+            <a class="link" href="{{default url name}}" target="_blank">{{default name url 'link'}}</a>
+        </span>
+        {{/each}}
+    </div>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-owner/OwnerView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-owner/OwnerView.hbs
@@ -1,4 +1,4 @@
 {{#if owner}}
     <h3 class="pane__section-title">{{t 'testResult.owner.name'}}</h3>
-    <div>{{owner}}</div>
+    <div class="pane__section-content">{{owner}}</div>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-parameters/ParametersView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-parameters/ParametersView.hbs
@@ -1,5 +1,6 @@
 {{#if parameters.length}}
-<h3>{{t 'testResult.parameters.name'}}</h3>
+<h3 class="pane__section-title">{{t 'testResult.parameters.name'}}</h3>
+<div class="pane__section-content">
     {{#each parameters}}
         <div class="environment long-line line-ellipsis">
             <span class="environment__key">{{#if name}}{{name}}{{else}}&lt;null&gt;{{/if}}</span>:
@@ -10,4 +11,5 @@
             {{/if}}
         </div>
     {{/each}}
+</div>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-severity/SeverityView.hbs
@@ -1,4 +1,6 @@
 {{#if severity}}
-    {{t 'testResult.severity.name'}}:
-    {{t (concat 'testResult.severity.' severity)}}
+    <span class="pane__section-title">{{t 'testResult.severity.name'}}</span>
+    <span class="pane__section-content" data-severity="{{severity}}">
+        {{t (concat 'testResult.severity.' severity)}}
+    </span>
 {{/if}}

--- a/allure-generator/src/main/javascript/plugins/testresult-tags/TagsView.hbs
+++ b/allure-generator/src/main/javascript/plugins/testresult-tags/TagsView.hbs
@@ -1,5 +1,8 @@
 {{#if tags}}
-    {{t 'testResult.tags.name'}}: {{#each tags}}
-        <span class="label label__info">{{#if this}}{{this}}{{else}}null{{/if}}</span>
-    {{/each}}
+    <span class="pane__section-title">{{t 'testResult.tags.name'}}</span>
+    <span class="pane__section-content">
+        {{#each tags}}
+            <span class="label label__info">{{#if this}}{{this}}{{else}}null{{/if}}</span>
+        {{/each}}
+    </span>
 {{/if}}


### PR DESCRIPTION
### Context

Adding a custom stylesheet to a generated Allure Report is not too complicated, especially if one uses plugins.

What is much more challenging, however, is to customize the core sections of the report, because they don't include enough HTML markup to target with custom CSS rules.

This pull request aims to standardize CSS class names across the Test Result section:
* `.pane__section-title` – now used in each `pane__section`.
* `.pane__section-content` – a new CSS class which wraps in a generic way all the content inside those panes: _severity_, _categories_, _tags_, _owner_, _duration_, etc.

| Markup | Screenshot |
| ------- | ------------ |
| ![DOM fragment on a screenshot](https://github.com/allure-framework/allure2/assets/1962469/c66e26d8-5794-449f-8a66-394b1f3da3ce) |  ![An actual screenshot of the refactored section, demonstrating that there are no visual changes](https://github.com/allure-framework/allure2/assets/1962469/1c5137d9-6155-44f6-86b9-afe0a0db8227) |

> [!NOTE]  
> There is a minor change to conciliate `h3.pane__section-title` and `span.pane__section-title` – the inline titles in `span` will have `::after` pseudo-element with a colon. This way we ensure that the colon is easy to add or remove in custom CSS styles.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] ~Provide unit tests~ (not applicable to Handlebars changes, I guess)
- [x] Check manually that the generated report has no visual regressions

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
