### PR TITLE
* Images are found not only in Test Stage but also in sub steps

### DIFF
--- a/plugins/screen-diff-plugin/src/dist/static/index.js
+++ b/plugins/screen-diff-plugin/src/dist/static/index.js
@@ -19,7 +19,27 @@
             if (matchedImage) {
                 return 'data/attachments/' + matchedImage.source;
             }
+            return findImageInSteps(data.testStage.steps, name)
         }
+        return null;
+    }
+
+    function findImageInSteps(steps, name) {
+        for (var index = 0; index < steps.length; index++) {
+            var matchedImage = steps[index].attachments.filter(function (attachment) {
+                return attachment.name === name;
+            })[0];
+
+            if (matchedImage) {
+                return "data/attachments/" + matchedImage.source;
+            }
+
+            var foundImage = findImageInSteps(steps[index].steps, name);
+            if (foundImage) {
+                return foundImage;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
### Context
In order for the image comparison plugin to work, the expected, actual and diff images must be in the attachments under the Test Stage. With the development, it can also find expected, actual and diff suffixes under any Step.

<img width="661" alt="Screenshot 2024-05-08 at 10 20 37" src="https://github.com/allure-framework/allure2/assets/29574704/95a08899-5130-4d46-9487-9e5596bf8d33">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
