### PR TITLE
Spelling fix in Interslavic translation

### DIFF
--- a/allure-generator/src/main/javascript/translations/isv.json
+++ b/allure-generator/src/main/javascript/translations/isv.json
@@ -32,9 +32,9 @@
         "shown_0": "{{count}} pokazany",
         "shown_1": "{{count}} pokazane",
         "shown_2": "{{count}} pokazane",
-        "total_0": "{{count}} test vsěgo",
-        "total_1": "{{count}} testy vsěgo",
-        "total_2": "{{count}} testov vsěgo"
+        "total_0": "{{count}} test vsego",
+        "total_1": "{{count}} testy vsego",
+        "total_2": "{{count}} testov vsego"
       },
       "groups": "Pokaži informaciju o grupah",
       "time": {
@@ -55,9 +55,9 @@
     },
     "widgetStatus": {
       "showAll": "Pokaži vsečto",
-      "total_0": "{{count}} element vsěgo",
-      "total_1": "{{count}} elementa vsěgo",
-      "total_2": "{{count}} elementov vsěgo"
+      "total_0": "{{count}} element vsego",
+      "total_1": "{{count}} elementa vsego",
+      "total_2": "{{count}} elementov vsego"
     }
   },
   "controls": {


### PR DESCRIPTION
### Context

Two weeks ago, Interslavic Dictionary received a batch of spelling fixes to eliminate very old inconsistencies, and one word [(`vsěgo` -> `vsego`)](https://github.com/medzuslovjansky/database/commit/4ee08ae5c7869f866250856bd0c5342e7c30cd73#diff-ac240aeb0d35e414461b9c95a46cb6508e0d1e1fb91d0edb051fc4cd1c97691dR9) from Allure's `isv.json` has been affected.

Changes like these (affecting standard orthography) do not happen often. We apologize for any inconvenience this may cause and thank you for your cooperation.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests (not applicable)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
