### PR TITLE
Fix RPM JRE dependency

### DIFF
--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -74,8 +74,6 @@ ospackage {
     os = org.redline_rpm.header.Os.LINUX
     release = "1"
 
-    requires("default-jre-headless")
-
     // Remove closureOf when https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/399 is fixed
     from("${pack}/bin", closureOf<CopySpec> {
         into("${dest}/bin")
@@ -97,10 +95,12 @@ ospackage {
 
 val buildDeb by tasks.existing(Deb::class) {
     dependsOn(preparePackageOutput)
+    requires("default-jre-headless")
 }
 
 val buildRpm by tasks.existing(Rpm::class) {
     dependsOn(preparePackageOutput)
+    requires("jre")
 }
 
 publishing {


### PR DESCRIPTION
### Context
Rpm package was not installed due to an incorrect dependency (default-jre-headless). In rpm repo this dependency called "jre"
