### PR TITLE
Expose "start" and "stop" timestamps as metrics

### DIFF
--- a/allure-plugin-api/src/main/java/io/qameta/allure/metric/TimeMetric.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/metric/TimeMetric.java
@@ -49,7 +49,9 @@ public class TimeMetric implements Metric {
                 lineFactory.apply("duration", zeroIfNull(groupTime.getDuration())),
                 lineFactory.apply("min_duration", zeroIfNull(groupTime.getMinDuration())),
                 lineFactory.apply("max_duration", zeroIfNull(groupTime.getMaxDuration())),
-                lineFactory.apply("sum_duration", zeroIfNull(groupTime.getSumDuration()))
+                lineFactory.apply("sum_duration", zeroIfNull(groupTime.getSumDuration())),
+                lineFactory.apply("start", zeroIfNull(groupTime.getStart())),
+                lineFactory.apply("stop", zeroIfNull(groupTime.getStop()))
         );
     }
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

In order to be able to track whether tests actually ran, there should be some sort of timestamp in Prometheus / influxdb metrics.

This PR exposes existing `start` and `stop` timestamps from `GroupTime` as metrics inside the `TimeMetric` class. I guess they were simply overlooked as all other properties of  `GroupTime`  are already exposed.

Three are no existing unit tests for the involved classes, so not sure where would one add them and what to test there.

This fixes an existing issue #889.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
