### PR TITLE
Add attachment support to JUnit XML plugin

### DIFF
--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -127,9 +127,40 @@ class JunitXmlPluginTest {
         assertThat(testStage.getAttachments())
                 .describedAs("Should add an attachment")
                 .hasSize(1)
-                .describedAs("Attachment should has right uid and name")
+                .describedAs("Attachment should have right uid and name")
                 .extracting(Attachment::getName, Attachment::getUid)
                 .containsExactly(Tuple.tuple("System out", "some-uid"));
+    }
+
+    @Test
+    void shouldAddSystemOutAsAttachment() throws Exception {
+        final Attachment hey = new Attachment().setUid("some-uid");
+        when(visitor.visitAttachmentFile(any())).thenReturn(hey);
+        process(
+                "junitdata/TEST-test.Attachment.xml", "TEST-test.Attachment.xml"
+        );
+        
+        final ArgumentCaptor<Path> attachmentCaptor = ArgumentCaptor.captor();
+        verify(visitor, times(1)).visitAttachmentFile(attachmentCaptor.capture());
+
+        assertThat(attachmentCaptor.getValue())
+                .isRegularFile()
+                .hasContent("some-test-log");
+
+        final ArgumentCaptor<TestResult> captor = ArgumentCaptor.captor();
+        verify(visitor, times(1)).visitTestResult(captor.capture());
+
+        final StageResult testStage = captor.getValue().getTestStage();
+        assertThat(testStage)
+                .describedAs("Should create a test stage")
+                .isNotNull();
+
+        assertThat(testStage.getAttachments())
+                .describedAs("Should add an attachment")
+                .hasSize(1)
+                .describedAs("Attachment should have right uid and name")
+                .extracting(Attachment::getName, Attachment::getUid)
+                .containsExactly(Tuple.tuple("test.SampleTest.txt", "some-uid"));
     }
 
     @Test

--- a/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.Attachment.xml
+++ b/plugins/junit-xml-plugin/src/test/resources/junitdata/TEST-test.Attachment.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite tests="1" failures="1" name="test.Attachment" time="2.055" errors="0" skipped="0">
+    <testcase classname="test.Attachment" name="shouldAddAttachment" time="1.051">
+        <system-out>Step 1
+Step 2
+Step 3
+[[ATTACHMENT|src/test/resources/junitdata/test.SampleTest.txt]]</system-out>
+        <failure message="some-message"><![CDATA[some-trace]]></failure>
+    </testcase>
+</testsuite>


### PR DESCRIPTION
### Context
Allows adding attachments from system-out in the format `[[ATTACHMENT|path/to/file]]` 
Here are some examples of others using this format:
https://plugins.jenkins.io/junit-attachments/
https://devblogs.microsoft.com/devops/junit-attachments-support-for-publish-test-results/
https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html#view-junit-screenshots-on-gitlab

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
