### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure2/security/code-scanning/9](https://github.com/allure-framework/allure2/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the jobs. For this workflow:
- The `build` job primarily uses `actions/checkout` and `actions/upload-artifact`, which require `contents: read`.
- The `testcmd` job uses `actions/download-artifact`, which also requires `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more concise and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
