### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure2/security/code-scanning/7](https://github.com/allure-framework/allure2/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: read` is needed for reading repository contents.
- `contents: write` is required for uploading release assets to GitHub.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. This ensures that the `GITHUB_TOKEN` has only the necessary permissions throughout the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
