### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,7 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   validation:


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure2/security/code-scanning/4](https://github.com/allure-framework/allure2/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only involves reading repository contents and validating the Gradle wrapper, the minimal permissions required are `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`validation`) to limit permissions for that job only. In this case, adding it at the root level is sufficient and concise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
