### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure2/security/code-scanning/6](https://github.com/allure-framework/allure2/security/code-scanning/6)

To fix the issue, add a `permissions` block to the workflow. Since the workflow interacts with labels and uses the `GITHUB_TOKEN`, it likely requires `contents: read` and `issues: write` permissions. These permissions allow the workflow to read repository contents and modify issue labels, respectively. The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
