### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,10 @@ name: "Set theme labels"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure2/security/code-scanning/3](https://github.com/allure-framework/allure2/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow uses the `actions/labeler@v4` action, it likely requires `contents: read` to access repository files and `pull-requests: write` to modify pull request labels. The `permissions` block should be added at the root level of the workflow to apply to all jobs, ensuring minimal and explicit permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
