### PR TITLE
Add support for XHTML rendering

### DIFF
--- a/allure-generator/src/main/javascript/utils/attachmentType.js
+++ b/allure-generator/src/main/javascript/utils/attachmentType.js
@@ -41,6 +41,7 @@ export default function typeByMime(type) {
         icon: "fa fa-file-text-o",
         parser: (d) => d,
       };
+    case "application/xhtml+xml":
     case "text/html":
       return {
         type: "html",


### PR DESCRIPTION
### Context

A bit exotic feature, but you never know when you need some obscure thing from 2000s. 😅 

As a user of Allure reports, I have to attach XML files with embedded XSL stylesheets, and the least problematic MIME type for them is, surprisingly, `application/xhtml+xml`. 

1. Browsers correctly render them when given URLs where the header contains `Content-Type: application/xhtml+xml`. Unfortunately, `text/html` is less predictable and there are rendering problems with it.
2. In Allure reports, `*.xml` files are rendered as a `code` by default, but we don't want this specifically for styled XML files - it is preferable if they render interactively, just like `.html` attachments. This MIME type serves as a clear intent that we are know what we are doing.

| text/html (actual) | application/xhtml+xml (expected) |
| --- | --- |
| ![actual](https://github.com/user-attachments/assets/5b43155b-da3d-44ed-8703-7c269c30e016) | ![expected](https://github.com/user-attachments/assets/b5ba41ad-9e4d-422e-8ce1-cab864f1cbac) |

#### Checklist

- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
