### PR TITLE
rework working flow with trace view

### DIFF
--- a/allure-generator/src/main/javascript/components/attachment/AttachmentView.hbs
+++ b/allure-generator/src/main/javascript/components/attachment/AttachmentView.hbs
@@ -50,12 +50,20 @@
     </div>
 {{else if (eq type "playwright-trace")}}
     <div class="{{b 'attachment__trace-container' fullscreen=fullScreen}}">
-        <iframe
-            id="pw-trace-iframe"
-            width="100%"
-            height="100%"
-            src="https://trace.playwright.dev/next/"
-        ></iframe>
+        <div class="attachment__trace-actions">
+            <a class="link attachment__trace-download" href="{{sourceUrl}}" target="_blank" rel="noreferrer noopener">
+                <span class="fa fa-download"></span>
+                Download attachment (trace.zip)
+            </a>
+            <span class="attachment__trace-sep">|</span>
+            <a class="link attachment__trace-open" href="https://trace.playwright.dev/next/" target="_blank" rel="noreferrer noopener">
+                <span class="fa fa-external-link"></span>
+                Open Playwright Trace Viewer
+            </a>
+        </div>
+        <div class="attachment__trace-hint">
+            Upload the downloaded zip into Trace Viewer (Drag & Drop).
+        </div>
     </div>
 {{else if (eq type "html")}}
         <iframe class="{{b 'attachment__iframe' fullscreen=fullScreen}}" frameborder="0" src="{{sourceUrl}}"></iframe>

--- a/allure-generator/src/main/javascript/components/attachment/styles.scss
+++ b/allure-generator/src/main/javascript/components/attachment/styles.scss
@@ -73,5 +73,30 @@
   &__trace-container {
     overflow: hidden;
     height: calc(100vh - 96px); //48px header, 48px footer space
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    text-align: center;
+    gap: 10px;
+  }
+
+  &__trace-actions {
+    font-size: 18px;
+    line-height: 1.35;
+    font-weight: 600;
+  }
+
+  &__trace-sep {
+    margin: 0 10px;
+    color: $text-muted-color;
+    font-weight: 400;
+  }
+
+  &__trace-hint {
+    font-size: 14px;
+    color: $text-muted-color;
+    max-width: 900px;
   }
 }

--- a/allure-generator/src/main/javascript/components/testresult-execution/TestResultExecutionView.js
+++ b/allure-generator/src/main/javascript/components/testresult-execution/TestResultExecutionView.js
@@ -53,9 +53,6 @@ class TestResultExecutionView extends View {
 
   @on("click .attachment-row")
   onAttachmentClick(e) {
-    if (e.currentTarget.attributes["data-type"].nodeValue=== "application/vnd.allure.playwright-trace") {
-        return
-    }
     const attachmentUid = $(e.currentTarget).data("uid");
     const name = `attachment__${attachmentUid}`;
 

--- a/allure-generator/src/main/resources/trace-viewer/index.html
+++ b/allure-generator/src/main/resources/trace-viewer/index.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Playwright Trace Viewer</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0b0f19;
+        --fg: #e5e7eb;
+        --muted: #9ca3af;
+        --card: rgba(255, 255, 255, 0.06);
+        --border: rgba(255, 255, 255, 0.12);
+        --btn: #2563eb;
+        --btnText: #ffffff;
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          --bg: #f6f7fb;
+          --fg: #111827;
+          --muted: #4b5563;
+          --card: rgba(17, 24, 39, 0.04);
+          --border: rgba(17, 24, 39, 0.12);
+        }
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          "Apple Color Emoji",
+          "Segoe UI Emoji";
+        background: var(--bg);
+        color: var(--fg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+        box-sizing: border-box;
+      }
+      .card {
+        max-width: 860px;
+        width: 100%;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 18px 18px 14px;
+      }
+      h1 {
+        margin: 0 0 10px;
+        font-size: 16px;
+        font-weight: 700;
+      }
+      p {
+        margin: 0 0 12px;
+        color: var(--muted);
+        line-height: 1.4;
+        font-size: 13px;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .btn {
+        appearance: none;
+        border: 0;
+        background: var(--btn);
+        color: var(--btnText);
+        padding: 10px 12px;
+        border-radius: 10px;
+        font-weight: 700;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      .btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .link {
+        font-size: 12px;
+        color: var(--muted);
+        word-break: break-all;
+      }
+      .error {
+        margin-top: 10px;
+        font-size: 12px;
+        color: #fca5a5;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Playwright Trace Viewer</h1>
+      <p>
+        This report opens traces in the official Playwright Trace Viewer as a top-level page to avoid
+        cross-origin iframe restrictions (e.g., Firefox in Jenkins).
+      </p>
+      <div class="row">
+        <button id="open" class="btn" type="button">Open trace in Playwright Trace Viewer</button>
+        <span id="trace" class="link" aria-label="Trace URL"></span>
+      </div>
+      <div id="error" class="error" role="alert" hidden></div>
+    </div>
+    <script src="./viewer.js"></script>
+  </body>
+</html>

--- a/allure-generator/src/main/resources/trace-viewer/viewer.js
+++ b/allure-generator/src/main/resources/trace-viewer/viewer.js
@@ -1,0 +1,38 @@
+(function init() {
+  const openBtn = document.getElementById("open");
+  const traceEl = document.getElementById("trace");
+  const errorEl = document.getElementById("error");
+
+  const params = new URLSearchParams(window.location.search || "");
+  const traceParam = params.get("trace");
+
+  if (traceParam) {
+    try {
+      traceEl.textContent = decodeURIComponent(traceParam);
+    } catch (e) {
+      traceEl.textContent = traceParam;
+    }
+  } else {
+    traceEl.textContent = "No trace URL provided";
+    openBtn.disabled = true;
+  }
+
+  function setError(text) {
+    errorEl.hidden = !text;
+    errorEl.textContent = text || "";
+  }
+
+  openBtn.addEventListener("click", () => {
+    setError("");
+    if (!traceParam) {
+      setError("Missing trace URL. The report did not provide ?trace=... parameter.");
+      return;
+    }
+
+    const viewerUrl = `https://trace.playwright.dev/?trace=${traceParam}`;
+    const win = window.open(viewerUrl, "_blank", "noopener,noreferrer");
+    if (!win) {
+      setError("Popup blocked. Allow popups for this report to open the trace viewer.");
+    }
+  });
+})();


### PR DESCRIPTION
Removed the embedded iframe with the Trace Viewer.

Now showing two explicit actions:

1. Download attachment (trace.zip) — download the trace
2. Open Playwright Trace Viewer — open the viewer in a new tab

Added a hint: upload the downloaded zip into the Trace Viewer (Drag & Drop).

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
