### PR TITLE
Fix Windows start scripts classpath

### DIFF
--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -38,11 +38,9 @@ tasks.distTar {
     compression = Compression.GZIP
 }
 
-val main = sourceSets.getByName("main")
-
 val startScripts by tasks.existing(CreateStartScripts::class) {
     applicationName = "allure"
-    classpath = fileTree("src/lib") + files("src/lib/config")
+    classpath = files(tasks.jar) + configurations.runtimeClasspath.get() + files("src/lib/config")
     doLast {
         unixScript.writeText(unixScript.readText()
                 .replace(Regex("(?m)^APP_HOME="), "export APP_HOME=")

--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -42,7 +42,7 @@ val main = sourceSets.getByName("main")
 
 val startScripts by tasks.existing(CreateStartScripts::class) {
     applicationName = "allure"
-    classpath = files("src/lib/*", "src/lib/config")
+    classpath = fileTree("src/lib") + files("src/lib/config")
     doLast {
         unixScript.writeText(unixScript.readText()
                 .replace(Regex("(?m)^APP_HOME="), "export APP_HOME=")


### PR DESCRIPTION
This PR fixes `startScripts` generation on Windows.

Before this change, running:

```bash
./gradlew.bat :allure-commandline:startScripts
```

failed with:

```text
Illegal char <*> at index ... src/lib/*
```

The previous classpath used a wildcard path with `files(...)`, which can be interpreted as an invalid path on Windows because of the `*` character.

### Changes

Replaced the wildcard path with `fileTree("src/lib")` while keeping `src/lib/config` on the classpath.

### Verification

Verified on Windows with:

```bash
./gradlew.bat :allure-commandline:startScripts
```

Result:

```text
BUILD SUCCESSFUL
```