### PR TITLE
docs: align ALLURE_NO_ANALYTICS opt-out example with implementation

### DIFF
--- a/Analytics.md
+++ b/Analytics.md
@@ -24,5 +24,5 @@ Allure analytics helps us maintainers and leaving it on is appreciated. However,
 Allure's analytics, you can set this variable in your environment:
 
 ```$xslt
-export ALLURE_NO_ANALYTICS=1
+export ALLURE_NO_ANALYTICS=true
 ``` 


### PR DESCRIPTION
### Context

[`Analytics.md`](Analytics.md#opting-out) documents the opt-out as:

```bash
export ALLURE_NO_ANALYTICS=1
```

The two halves of the analytics path use different semantics on this variable:

- `GaPlugin` (server-side): any non-null value disables → `=1` works.
- `ReportWebGenerator` (HTML side): parses through `Boolean.parseBoolean`, which only treats `"true"` (case-insensitive) as a disable signal → `=1` is ignored, and `gtag.js` still loads from `googletagmanager.com` in the rendered report.

So the documented opt-out only half-works. The implementation already honours `=true` end-to-end — covered by the existing `ReportWebGeneratorTest#shouldDisableAnalytics`, which was further tightened (and the template's stray inline `gtag('config', …)` block was moved inside the `analyticsDisable` guard) in #3332.

The cheapest fix is to update the documentation to recommend the value the implementation honours. Net diff: one line in `Analytics.md`.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests _(no new tests; existing `shouldDisableAnalytics` already exercises the `=true` path)_

[cla]: https://cla-assistant.io/accept/allure-framework/allure2