### PR TITLE
Fix XSS in rendered report: HTML-escape user-controlled reportLanguage

### DIFF
--- a/allure-generator/src/main/resources/tpl/index.html.ftl
+++ b/allure-generator/src/main/resources/tpl/index.html.ftl
@@ -10,7 +10,7 @@
 <#-- @ftlvariable name="reportName" type="java.lang.String" -->
 <#-- @ftlvariable name="reportLanguage" type="java.lang.String" -->
 <!DOCTYPE html>
-<html dir="ltr" lang="${reportLanguage!"en"}">
+<html dir="ltr" lang="${(reportLanguage!"en")?html}">
 <head>
     <meta charset="utf-8">
     <meta name="allure-report-uuid" content="${reportUuid}">

--- a/allure-generator/src/test/java/io/qameta/allure/core/ReportWebGeneratorTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/core/ReportWebGeneratorTest.java
@@ -105,6 +105,29 @@ class ReportWebGeneratorTest {
     }
 
     /**
+     * Verifies that a hostile {@code reportLanguage} containing live HTML
+     * cannot escape the {@code lang} attribute on the root {@code <html>} tag.
+     */
+    @Description
+    @Test
+    void shouldEscapeHtmlInReportLanguage(@TempDir final Path tempDirectory) {
+        final String hostile = "en\"><script>alert('xss')</script>";
+        final Configuration configuration = ConfigurationBuilder.empty()
+                .withReportLanguage(hostile)
+                .build();
+        final InMemoryReportStorage reportStorage = new InMemoryReportStorage();
+        generateReport(configuration, reportStorage, tempDirectory);
+
+        final Path indexHtml = tempDirectory.resolve("index.html");
+
+        assertThat(indexHtml)
+                .isRegularFile()
+                .content(StandardCharsets.UTF_8)
+                .as("hostile reportLanguage must not break out of the lang attribute")
+                .doesNotContain(hostile);
+    }
+
+    /**
      * Verifies setting language for web report generation.
      */
     @Description


### PR DESCRIPTION
### Context

Sister to #3334. `reportLanguage` is set via `ConfigurationBuilder#withReportLanguage` and interpolated into the `lang` attribute on the root `<html>` tag in `index.html.ftl`. With no auto-escaping configured on the FreeMarker context, a value like

```
en"><script>alert('xss')</script>
```

breaks out of the attribute and injects live markup. Apply per-variable HTML escaping at the bug site:

```diff
-<html dir="ltr" lang="${reportLanguage!"en"}">
+<html dir="ltr" lang="${(reportLanguage!"en")?html}">
```

Existing `shouldSetLanguage` and `shouldSetDefaultLanguageIfNotProvided` tests continue to pass — escaping a value with no HTML metacharacters is a no-op.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2