### PR TITLE
Preserve known and muted markers from on-disk statusDetails on import

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
@@ -199,6 +199,15 @@ public class Allure2Plugin implements Reader {
             dest.setStatusMessage(details.getMessage());
             dest.setStatusTrace(details.getTrace());
             dest.setFlaky(details.isFlaky());
+            // Preserve known / muted markers from the on-disk schema so triage state
+            // stays reachable on the entity (Allure 3 readers consume these fields).
+            // Stored only when set to keep the extra-block free of default-valued noise.
+            if (details.isKnown()) {
+                dest.addExtraBlock("statusDetailsKnown", true);
+            }
+            if (details.isMuted()) {
+                dest.addExtraBlock("statusDetailsMuted", true);
+            }
         });
 
         dest.setLinks(convertList(result.getLinks(), this::convert));

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -250,6 +250,33 @@ class Allure2PluginTest {
     }
 
     /**
+     * Verifies that {@code known} and {@code muted} markers from the on-disk
+     * statusDetails are preserved on the entity through the extra-block
+     * channel, matching Allure 3 reader behaviour.
+     */
+    @Description
+    @Test
+    void shouldPreserveKnownAndMutedFromStatusDetails() throws Exception {
+        Set<TestResult> testResults = process(
+                "allure2/status-details-known-muted.json", generateTestResultName()
+        ).getResults();
+
+        assertThat(testResults)
+                .hasSize(1)
+                .first()
+                .satisfies(
+                        result -> {
+                            assertThat(result.<Boolean>getExtraBlock("statusDetailsKnown"))
+                                    .as("known marker from on-disk statusDetails should be preserved")
+                                    .isTrue();
+                            assertThat(result.<Boolean>getExtraBlock("statusDetailsMuted"))
+                                    .as("muted marker from on-disk statusDetails should be preserved")
+                                    .isTrue();
+                        }
+                );
+    }
+
+    /**
      * Verifies processing null stage time for Allure 2 parsing.
      */
     @Description

--- a/allure-generator/src/test/resources/allure2/status-details-known-muted.json
+++ b/allure-generator/src/test/resources/allure2/status-details-known-muted.json
@@ -1,0 +1,15 @@
+{
+  "uuid": "9f0a2c43-5e21-4b8a-a312-9c4e8b1d2030",
+  "name": "shouldPreserveKnownAndMuted",
+  "fullName": "io.qameta.allure.RedTest#shouldPreserveKnownAndMuted",
+  "historyId": "history-known-muted-001",
+  "status": "failed",
+  "statusDetails": {
+    "message": "expected something else",
+    "trace": "stacktrace-omitted",
+    "known": true,
+    "muted": true
+  },
+  "start": 1700000000000,
+  "stop": 1700000000050
+}


### PR DESCRIPTION
### Context

Sister to #3336. The on-disk Allure 2 schema (allure-java's [`StatusDetails`](https://github.com/allure-framework/allure-java/blob/master/allure-model/src/main/java/io/qameta/allure/model/StatusDetails.java)) carries `known` and `muted` booleans alongside `message`, `trace`, and `flaky`. Allure 3's reader maps all five. Allure 2's `Allure2Plugin#convert` reads only the first three, so triage state is silently dropped on import.

This PR stops the data from being lost: when set, `known` and `muted` are stashed on the entity via the generic extra-block channel (`entity.TestResult#addExtraBlock`), keyed `statusDetailsKnown` / `statusDetailsMuted`. Same shape as the recent `titlePath` preservation change — minimal data preservation, no commitment to a specific UI projection.

Whether to elevate these to first-class fields on `entity.TestResult`, project as labels, or render dedicated badges is a follow-up worth its own discussion; this PR only stops the information from being lost.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2