### PR TITLE
Add label-grouped report tabs

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/ConfigurationBuilder.java
+++ b/allure-generator/src/main/java/io/qameta/allure/ConfigurationBuilder.java
@@ -39,6 +39,7 @@ import io.qameta.allure.history.HistoryPlugin;
 import io.qameta.allure.history.HistoryTrendPlugin;
 import io.qameta.allure.idea.IdeaLinksPlugin;
 import io.qameta.allure.influxdb.InfluxDbExportPlugin;
+import io.qameta.allure.labels.LabelTabsPlugin;
 import io.qameta.allure.launch.LaunchPlugin;
 import io.qameta.allure.mail.MailPlugin;
 import io.qameta.allure.owner.OwnerPlugin;
@@ -93,6 +94,7 @@ public class ConfigurationBuilder {
             new DurationPlugin(),
             new DurationTrendPlugin(),
             new StatusChartPlugin(),
+            new LabelTabsPlugin(),
             new TimelinePlugin(),
             new SuitesPlugin(),
             new TestsResultsPlugin(),
@@ -171,6 +173,7 @@ public class ConfigurationBuilder {
                         new DurationPlugin(),
                         new DurationTrendPlugin(),
                         new StatusChartPlugin(),
+                        new LabelTabsPlugin(),
                         new TimelinePlugin(),
                         new SuitesPlugin(),
                         new TestsResultsPlugin(),

--- a/allure-generator/src/main/java/io/qameta/allure/labels/LabelTabsPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/labels/LabelTabsPlugin.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.labels;
+
+import io.qameta.allure.CommonJsonAggregator2;
+import io.qameta.allure.CompositeAggregator2;
+import io.qameta.allure.core.LaunchResults;
+import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.entity.TestResult;
+import io.qameta.allure.tree.TestResultTree;
+import io.qameta.allure.tree.Tree;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static io.qameta.allure.entity.TestResult.comparingByTimeAsc;
+import static io.qameta.allure.tree.TreeUtils.groupByLabels;
+
+/**
+ * Generates tree data for label-based report tabs.
+ */
+public class LabelTabsPlugin extends CompositeAggregator2 {
+
+    public static final String TAGS = "tags";
+
+    public static final String ISSUES = "issues";
+
+    public static final String TEST_TYPES = "test-types";
+
+    private static final String JSON_EXTENSION = ".json";
+
+    public LabelTabsPlugin() {
+        super(
+                Arrays.asList(
+                        new LabelTreeAggregator(TAGS, TAGS + JSON_EXTENSION, LabelName.TAG),
+                        new LabelTreeAggregator(ISSUES, ISSUES + JSON_EXTENSION, LabelName.ISSUE),
+                        new LabelTreeAggregator(TEST_TYPES, TEST_TYPES + JSON_EXTENSION, LabelName.TEST_TYPE)
+                )
+        );
+    }
+
+    static Tree<TestResult> getData(final List<LaunchResults> launchResults,
+                                    final String treeName,
+                                    final LabelName labelName) {
+
+        final Tree<TestResult> labels = new TestResultTree(
+                treeName,
+                testResult -> groupByLabels(testResult, labelName)
+        );
+
+        launchResults.stream()
+                .map(LaunchResults::getResults)
+                .flatMap(Collection::stream)
+                .filter(testResult -> !testResult.findAllLabels(labelName).isEmpty())
+                .sorted(comparingByTimeAsc())
+                .forEach(labels::add);
+        return labels;
+    }
+
+    private static class LabelTreeAggregator extends CommonJsonAggregator2 {
+
+        private final String treeName;
+
+        private final LabelName labelName;
+
+        LabelTreeAggregator(final String treeName, final String fileName, final LabelName labelName) {
+            super(fileName);
+            this.treeName = treeName;
+            this.labelName = labelName;
+        }
+
+        @Override
+        protected Object getData(final List<LaunchResults> launches) {
+            return LabelTabsPlugin.getData(launches, treeName, labelName);
+        }
+    }
+}

--- a/allure-generator/src/main/javascript/core/registry/index.mts
+++ b/allure-generator/src/main/javascript/core/registry/index.mts
@@ -9,6 +9,7 @@ import {
   overviewTab,
   widgetsByTab as overviewWidgets,
 } from "../../features/overview/index.mts";
+import { issuesTab, tagsTab, testTypesTab } from "../../features/labels/index.mts";
 import { packagesTab } from "../../features/packages/index.mts";
 import { suitesTab } from "../../features/suites/index.mts";
 import { testResultBlocks, testResultTabs } from "../../features/test-result/index.mts";
@@ -41,6 +42,9 @@ const tabs: TabDescriptor[] = [
   categoriesTab,
   suitesTab,
   behaviorsTab,
+  tagsTab,
+  issuesTab,
+  testTypesTab,
   packagesTab,
   graphTab,
   timelineTab,

--- a/allure-generator/src/main/javascript/features/labels/index.mts
+++ b/allure-generator/src/main/javascript/features/labels/index.mts
@@ -1,0 +1,22 @@
+import { createTreeTab } from "../tree/createTreeTab.mts";
+
+export const tagsTab = createTreeTab({
+  baseUrl: "tags",
+  title: "tab.tags.name",
+  icon: "lineHelpersFlag",
+  url: "data/tags.json",
+});
+
+export const issuesTab = createTreeTab({
+  baseUrl: "issues",
+  title: "tab.issues.name",
+  icon: "lineGeneralLink1",
+  url: "data/issues.json",
+});
+
+export const testTypesTab = createTreeTab({
+  baseUrl: "test-types",
+  title: "tab.testTypes.name",
+  icon: "lineGeneralChecklist3",
+  url: "data/test-types.json",
+});

--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -133,6 +133,9 @@
     "behaviors": {
       "name": "Behaviors"
     },
+    "issues": {
+      "name": "Issues"
+    },
     "graph": {
       "name": "Graphs"
     },
@@ -144,6 +147,12 @@
     },
     "suites": {
       "name": "Suites"
+    },
+    "tags": {
+      "name": "Tags"
+    },
+    "testTypes": {
+      "name": "Test types"
     },
     "timeline": {
       "name": "Timeline",

--- a/allure-generator/src/test/java/io/qameta/allure/labels/LabelTabsPluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/labels/LabelTabsPluginTest.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.labels;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.ConfigurationBuilder;
+import io.qameta.allure.Description;
+import io.qameta.allure.core.Configuration;
+import io.qameta.allure.core.InMemoryReportStorage;
+import io.qameta.allure.core.LaunchResults;
+import io.qameta.allure.entity.Label;
+import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.entity.TestResult;
+import io.qameta.allure.tree.Tree;
+import io.qameta.allure.tree.TreeNode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static io.qameta.allure.testdata.TestData.createSingleLaunchResults;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LabelTabsPluginTest {
+
+    @Description
+    @Test
+    void shouldCreateTagTree() {
+        final Tree<TestResult> tree = Allure.step(
+                "Build tag tree from launch results",
+                () -> LabelTabsPlugin.getData(
+                        getLaunchResults(),
+                        LabelTabsPlugin.TAGS,
+                        LabelName.TAG
+                )
+        );
+
+        assertThat(tree.getChildren())
+                .extracting(TreeNode::getName)
+                .containsExactlyInAnyOrder("api", "smoke");
+    }
+
+    @Description
+    @Test
+    void shouldCreateIssueTree() {
+        final Tree<TestResult> tree = Allure.step(
+                "Build issue tree from launch results",
+                () -> LabelTabsPlugin.getData(
+                        getLaunchResults(),
+                        LabelTabsPlugin.ISSUES,
+                        LabelName.ISSUE
+                )
+        );
+
+        assertThat(tree.getChildren())
+                .extracting(TreeNode::getName)
+                .containsExactlyInAnyOrder("AUTH-1", "BILL-2");
+    }
+
+    @Description
+    @Test
+    void shouldCreateReportDataFiles() {
+        final Configuration configuration = ConfigurationBuilder.bundled().build();
+        final LabelTabsPlugin plugin = new LabelTabsPlugin();
+        final InMemoryReportStorage storage = new InMemoryReportStorage();
+
+        Allure.step("Aggregate label tab report files", () -> {
+            plugin.aggregate(configuration, getLaunchResults(), storage);
+            attachStorageFiles(storage);
+        });
+
+        assertThat(storage.getReportDataFiles())
+                .containsKeys(
+                        "data/tags.json",
+                        "data/issues.json",
+                        "data/test-types.json"
+                );
+    }
+
+    private void attachStorageFiles(final InMemoryReportStorage storage) {
+        Allure.step(
+                "Attach in-memory storage contents", () -> storage.getReportDataFiles().entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .forEach(
+                                entry -> Allure.addAttachment(
+                                        entry.getKey(),
+                                        "text/plain",
+                                        new String(
+                                                Base64.getDecoder().decode(entry.getValue()),
+                                                StandardCharsets.UTF_8
+                                        )
+                                )
+                        )
+        );
+    }
+
+    private List<LaunchResults> getLaunchResults() {
+        final TestResult first = new TestResult()
+                .setName("first")
+                .setLabels(
+                        Arrays.asList(
+                                new Label().setName("tag").setValue("smoke"),
+                                new Label().setName("issue").setValue("AUTH-1"),
+                                new Label().setName("testType").setValue("api")
+                        )
+                );
+        final TestResult second = new TestResult()
+                .setName("second")
+                .setLabels(
+                        Arrays.asList(
+                                new Label().setName("tag").setValue("api"),
+                                new Label().setName("issue").setValue("BILL-2"),
+                                new Label().setName("testType").setValue("ui")
+                        )
+                );
+        final TestResult third = new TestResult()
+                .setName("third")
+                .setLabels(Arrays.asList(new Label().setName("tag").setValue("smoke")));
+        return createSingleLaunchResults(second, first, third);
+    }
+}


### PR DESCRIPTION
Fixes #1108.

Summary:
- Adds bundled label-grouped tree data for `tag`, `issue`, and `testType` labels.
- Registers new report tabs for Tags, Issues, and Test types using the existing tree layout.
- Filters unlabeled results out of each label-specific tree so the tabs only show relevant groups.
- Adds unit coverage for tag/issue grouping and generated report data files.

Verification:
- `./gradlew.bat :allure-generator:test --tests io.qameta.allure.labels.LabelTabsPluginTest -x :allure-generator:testWeb`
- `./gradlew.bat :allure-generator:checkstyleMain :allure-generator:checkstyleTest :allure-generator:spotlessJavaCheck :allure-generator:spotlessMiscCheck`
- `./gradlew.bat :allure-generator:buildWeb`