### PR TITLE
Show retries and instant tests on the Timeline

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/timeline/TimelinePlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/timeline/TimelinePlugin.java
@@ -15,16 +15,23 @@
  */
 package io.qameta.allure.timeline;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.qameta.allure.CommonJsonAggregator2;
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.entity.Status;
 import io.qameta.allure.entity.TestResult;
-import io.qameta.allure.tree.TestResultTree;
+import io.qameta.allure.entity.Time;
+import io.qameta.allure.tree.AbstractTree;
+import io.qameta.allure.tree.DefaultTreeLeaf;
+import io.qameta.allure.tree.TestResultGroupFactory;
+import io.qameta.allure.tree.TestResultTreeGroup;
 import io.qameta.allure.tree.Tree;
 
 import java.util.Collection;
 import java.util.List;
 
+import static io.qameta.allure.tree.TreeUtils.createGroupUid;
 import static io.qameta.allure.tree.TreeUtils.groupByLabels;
 
 /**
@@ -34,22 +41,79 @@ import static io.qameta.allure.tree.TreeUtils.groupByLabels;
  */
 public class TimelinePlugin extends CommonJsonAggregator2 {
 
+    private static final String TIMELINE = "timeline";
+
     public TimelinePlugin() {
-        super("timeline.json");
+        super(TIMELINE + ".json");
     }
 
     @Override
     protected Tree<TestResult> getData(final List<LaunchResults> launchResults) {
 
-        final Tree<TestResult> timeline = new TestResultTree(
-                "timeline",
-                testResult -> groupByLabels(testResult, LabelName.HOST, LabelName.THREAD)
-        );
+        final Tree<TestResult> timeline = new TimelineTree();
 
         launchResults.stream()
                 .map(LaunchResults::getAllResults)
                 .flatMap(Collection::stream)
                 .forEach(timeline::add);
         return timeline;
+    }
+
+    private static final class TimelineTree extends AbstractTree<TestResult, TestResultTreeGroup, TimelineTreeLeaf> {
+
+        TimelineTree() {
+            super(
+                    new TestResultTreeGroup(createGroupUid(null, TIMELINE), TIMELINE),
+                    testResult -> groupByLabels(testResult, LabelName.HOST, LabelName.THREAD),
+                    new TestResultGroupFactory(),
+                    (parent, item) -> new TimelineTreeLeaf(item)
+            );
+        }
+
+        @JsonProperty("uid")
+        String getUid() {
+            return root.getUid();
+        }
+
+        @Override
+        protected Class<TestResultTreeGroup> getRootType() {
+            return TestResultTreeGroup.class;
+        }
+    }
+
+    private static final class TimelineTreeLeaf extends DefaultTreeLeaf {
+
+        private final String uid;
+        private final Status status;
+        private final Time time;
+        private final Boolean retry;
+
+        TimelineTreeLeaf(final TestResult testResult) {
+            super(testResult.getName());
+            this.uid = testResult.getUid();
+            this.status = testResult.getStatus();
+            this.time = testResult.getTime();
+            this.retry = testResult.isRetry() ? Boolean.TRUE : null;
+        }
+
+        @JsonProperty("uid")
+        String getUid() {
+            return uid;
+        }
+
+        @JsonProperty("status")
+        Status getStatus() {
+            return status;
+        }
+
+        @JsonProperty("time")
+        Time getTime() {
+            return time;
+        }
+
+        @JsonProperty("retry")
+        Boolean getRetry() {
+            return retry;
+        }
     }
 }

--- a/allure-generator/src/main/javascript/features/tree/views/TimelineView.mts
+++ b/allure-generator/src/main/javascript/features/tree/views/TimelineView.mts
@@ -33,6 +33,15 @@ const getTimelineResultLinkLabel = (result: TimelineTreeNode) => {
   return translate("tab.timeline.resultLink", { hash: { name, status } });
 };
 
+const getTimelineItemClassName = (result: TimelineTreeNode) =>
+  [
+    "timeline__item",
+    `timeline__item_status_${result.status || "unknown"}`,
+    result.retry ? "timeline__item_retry" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
 class TimelineView extends BaseChartView {
   rootClassName = "timeline";
 
@@ -266,10 +275,7 @@ class TimelineView extends BaseChartView {
         .attr("xlink:href", (d: TimelineTreeNode) => `#testresult/${d.uid}`)
         .attr("aria-label", getTimelineResultLinkLabel)
         .append("rect")
-        .attr(
-          "class",
-          (d: TimelineTreeNode) => `timeline__item timeline__item_status_${d.status || "unknown"}`,
-        )
+        .attr("class", getTimelineItemClassName)
         .attr("x", (d: TimelineTreeNode) => this.chartX(d.time?.start || 0))
         .attr("width", (d: TimelineTreeNode) =>
           this.chartX((d.time?.start || 0) + (d.time?.duration || 0)),

--- a/allure-generator/src/main/javascript/features/tree/views/TimelineView.mts
+++ b/allure-generator/src/main/javascript/features/tree/views/TimelineView.mts
@@ -19,6 +19,7 @@ const BRUSH_VIEW_HEIGHT = 48;
 const BAR_HEIGHT = 20;
 const BAR_GAP = 2;
 const PADDING = 30;
+const ZERO_DURATION_MARK_RADIUS = 5;
 
 type TimelineTreeNode = import("../../../types/report.mts").TreeNode;
 type LoadedTreeData = import("../model/treeData.mts").LoadedTreeData;
@@ -33,10 +34,17 @@ const getTimelineResultLinkLabel = (result: TimelineTreeNode) => {
   return translate("tab.timeline.resultLink", { hash: { name, status } });
 };
 
+const isZeroDurationResult = (result: TimelineTreeNode) => {
+  const durationValue = result.time?.duration;
+
+  return typeof durationValue === "number" && durationValue <= 0;
+};
+
 const getTimelineItemClassName = (result: TimelineTreeNode) =>
   [
     "timeline__item",
     `timeline__item_status_${result.status || "unknown"}`,
+    isZeroDurationResult(result) ? "timeline__item_zero" : "",
     result.retry ? "timeline__item_retry" : "",
   ]
     .filter(Boolean)
@@ -267,13 +275,16 @@ class TimelineView extends BaseChartView {
     parent: import("d3-selection").Selection<SVGGElement, unknown, null, undefined>,
   ) {
     if (items.length) {
-      const bars = parent
+      const links = parent
         .selectAll(".timeline__item")
         .data(items)
         .enter()
         .append("a")
         .attr("xlink:href", (d: TimelineTreeNode) => `#testresult/${d.uid}`)
-        .attr("aria-label", getTimelineResultLinkLabel)
+        .attr("aria-label", getTimelineResultLinkLabel);
+      const barLinks = links.filter((d: TimelineTreeNode) => !isZeroDurationResult(d));
+      const dotLinks = links.filter((d: TimelineTreeNode) => isZeroDurationResult(d));
+      const bars = barLinks
         .append("rect")
         .attr("class", getTimelineItemClassName)
         .attr("x", (d: TimelineTreeNode) => this.chartX(d.time?.start || 0))
@@ -283,8 +294,17 @@ class TimelineView extends BaseChartView {
         .attr("rx", 2)
         .attr("ry", 2)
         .attr("height", BAR_HEIGHT);
+      const dots = dotLinks
+        .raise()
+        .append("circle")
+        .attr("class", getTimelineItemClassName)
+        .attr("cx", (d: TimelineTreeNode) => this.chartX(d.time?.start || 0))
+        .attr("cy", BAR_HEIGHT / 2)
+        .attr("r", ZERO_DURATION_MARK_RADIUS);
       this.bindTooltip(bars);
+      this.bindTooltip(dots);
       bars.on("click", this.hideTooltip.bind(this));
+      dots.on("click", this.hideTooltip.bind(this));
       return BAR_HEIGHT + BAR_GAP;
     }
     return 0;
@@ -300,9 +320,12 @@ class TimelineView extends BaseChartView {
       const brushRange = selection as [number, number];
       this.chartX.domain(brushRange.map((value) => this.brushX.invert(value)) as [number, number]);
       this.svgChart
-        .selectAll<SVGRectElement, TimelineTreeNode>(".timeline__item")
+        .selectAll<SVGRectElement, TimelineTreeNode>("rect.timeline__item")
         .attr("x", (d) => start(d))
         .attr("width", (d) => stop(d) - start(d));
+      this.svgChart
+        .selectAll<SVGCircleElement, TimelineTreeNode>("circle.timeline__item_zero")
+        .attr("cx", (d) => start(d));
       this.svgBrush
         .select<SVGGElement>(".timeline__brush__axis_x")
         .call(

--- a/allure-generator/src/main/javascript/features/tree/views/TimelineView.scss
+++ b/allure-generator/src/main/javascript/features/tree/views/TimelineView.scss
@@ -60,6 +60,58 @@
     &_status_unknown {
       fill: var(--color-status-unknown-chart-fill);
     }
+
+    &_retry {
+      fill: url("#timeline-retry-unknown");
+    }
+
+    &_retry.timeline__item_status_failed {
+      fill: url("#timeline-retry-failed");
+    }
+
+    &_retry.timeline__item_status_broken {
+      fill: url("#timeline-retry-broken");
+    }
+
+    &_retry.timeline__item_status_passed {
+      fill: url("#timeline-retry-passed");
+    }
+
+    &_retry.timeline__item_status_skipped {
+      fill: url("#timeline-retry-skipped");
+    }
+
+    &_retry.timeline__item_status_unknown {
+      fill: url("#timeline-retry-unknown");
+    }
+  }
+
+  &__retry-pattern-base {
+    fill: var(--color-bg-primary);
+  }
+
+  &__retry-pattern-stripe {
+    fill: var(--color-status-unknown-chart-fill);
+  }
+
+  &__retry-pattern_status_failed &__retry-pattern-stripe {
+    fill: var(--color-status-failed-chart-fill);
+  }
+
+  &__retry-pattern_status_broken &__retry-pattern-stripe {
+    fill: var(--color-status-broken-chart-fill);
+  }
+
+  &__retry-pattern_status_passed &__retry-pattern-stripe {
+    fill: var(--color-status-passed-chart-fill);
+  }
+
+  &__retry-pattern_status_skipped &__retry-pattern-stripe {
+    fill: var(--color-status-skipped-chart-fill);
+  }
+
+  &__retry-pattern_status_unknown &__retry-pattern-stripe {
+    fill: var(--color-status-unknown-chart-fill);
   }
 
   &__group_title {

--- a/allure-generator/src/main/javascript/features/tree/views/renderTimelineView.mts
+++ b/allure-generator/src/main/javascript/features/tree/views/renderTimelineView.mts
@@ -1,9 +1,33 @@
 import { createElement, createFragment, createSvgElement } from "../../../shared/dom.mts";
 
+const statuses = ["failed", "broken", "passed", "skipped", "unknown"] as const;
+
 type TimelineTemplateOptions = {
   BRUSH_VIEW_HEIGHT: number;
   PADDING: number;
 };
+
+const createRetryPattern = (status: (typeof statuses)[number]) =>
+  createSvgElement("pattern", {
+    attrs: {
+      height: "8",
+      id: `timeline-retry-${status}`,
+      patternTransform: "rotate(45)",
+      patternUnits: "userSpaceOnUse",
+      width: "8",
+    },
+    className: `timeline__retry-pattern timeline__retry-pattern_status_${status}`,
+    children: [
+      createSvgElement("rect", {
+        attrs: { height: "8", width: "8", x: "0", y: "0" },
+        className: "timeline__retry-pattern-base",
+      }),
+      createSvgElement("rect", {
+        attrs: { height: "8", width: "3", x: "0", y: "0" },
+        className: "timeline__retry-pattern-stripe",
+      }),
+    ],
+  });
 
 export const createTimelineViewContent = ({
   BRUSH_VIEW_HEIGHT,
@@ -16,21 +40,26 @@ export const createTimelineViewContent = ({
         className: "timeline__chart",
         children: createSvgElement("svg", {
           className: "timeline__chart_svg",
-          children: createSvgElement("g", {
-            attrs: { transform: `translate(${PADDING}, 15)` },
-            children: [
-              createSvgElement("g", {
-                className: "timeline__slider",
-              }),
-              createSvgElement("g", {
-                attrs: { transform: `translate(0, ${PADDING})` },
-                className: "timeline__plot",
-                children: createSvgElement("g", {
-                  className: "timeline__chart__axis timeline__chart__axis_x",
+          children: [
+            createSvgElement("defs", {
+              children: statuses.map(createRetryPattern),
+            }),
+            createSvgElement("g", {
+              attrs: { transform: `translate(${PADDING}, 15)` },
+              children: [
+                createSvgElement("g", {
+                  className: "timeline__slider",
                 }),
-              }),
-            ],
-          }),
+                createSvgElement("g", {
+                  attrs: { transform: `translate(0, ${PADDING})` },
+                  className: "timeline__plot",
+                  children: createSvgElement("g", {
+                    className: "timeline__chart__axis timeline__chart__axis_x",
+                  }),
+                }),
+              ],
+            }),
+          ],
         }),
       }),
     }),

--- a/allure-generator/src/main/javascript/types/report.mts
+++ b/allure-generator/src/main/javascript/types/report.mts
@@ -109,6 +109,7 @@ export type TreeNode = {
   newBroken?: boolean;
   retriesCount?: number;
   retriesStatusChange?: boolean;
+  retry?: boolean;
   parameters?: string[];
   tags?: string[];
   children?: TreeNode[];

--- a/allure-generator/src/test/java/io/qameta/allure/timeline/TimelinePluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/timeline/TimelinePluginTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.timeline;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.qameta.allure.Allure;
+import io.qameta.allure.Description;
+import io.qameta.allure.core.LaunchResults;
+import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.entity.Status;
+import io.qameta.allure.entity.TestResult;
+import io.qameta.allure.entity.Time;
+import io.qameta.allure.retry.RetryPlugin;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static io.qameta.allure.testdata.TestData.createSingleLaunchResults;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimelinePluginTest {
+
+    private static final String FIRST_UID = "first-attempt";
+    private static final String SECOND_UID = "second-attempt";
+    private static final String LATEST_UID = "latest-attempt";
+
+    private final ObjectMapper mapper = JsonMapper.builder()
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .build();
+
+    private final RetryPlugin retryPlugin = new RetryPlugin();
+
+    private final TimelinePlugin timelinePlugin = new TimelinePlugin();
+
+    /**
+     * Verifies timeline JSON marks only retry attempts so the UI can render them as retry bars.
+     */
+    @Description
+    @Test
+    void shouldMarkRetriesInTimelineJson() throws Exception {
+        Allure.label("component", "timeline");
+        final String historyId = UUID.randomUUID().toString();
+        final List<LaunchResults> launchResults = createSingleLaunchResults(
+                createTestResult("first attempt", FIRST_UID, historyId, 1L, 9L),
+                createTestResult("second attempt", SECOND_UID, historyId, 11L, 19L),
+                createTestResult("latest attempt", LATEST_UID, historyId, 21L, 29L)
+        );
+
+        Allure.step("Aggregate retries before timeline generation", () -> {
+            retryPlugin.aggregate(null, launchResults, null);
+        });
+
+        final JsonNode timeline = Allure.step(
+                "Generate timeline tree after retry aggregation",
+                () -> mapper.valueToTree(timelinePlugin.getData(launchResults))
+        );
+        Allure.addAttachment(
+                "timeline-tree.json",
+                "application/json",
+                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(timeline),
+                ".json"
+        );
+
+        Allure.step("Verify only older attempts are marked as retry leaves", () -> {
+            final JsonNode firstAttempt = findByUid(timeline, FIRST_UID);
+            final JsonNode secondAttempt = findByUid(timeline, SECOND_UID);
+            final JsonNode latestAttempt = findByUid(timeline, LATEST_UID);
+
+            assertThat(firstAttempt.path("retry").asBoolean())
+                    .as("first attempt retry flag")
+                    .isTrue();
+            assertThat(secondAttempt.path("retry").asBoolean())
+                    .as("second attempt retry flag")
+                    .isTrue();
+            assertThat(latestAttempt.has("retry"))
+                    .as("latest attempt retry flag")
+                    .isFalse();
+            assertThat(fieldNames(firstAttempt))
+                    .as("retry attempt timeline fields")
+                    .containsExactlyInAnyOrder("name", "uid", "status", "time", "retry");
+            assertThat(fieldNames(latestAttempt))
+                    .as("latest attempt timeline fields")
+                    .containsExactlyInAnyOrder("name", "uid", "status", "time");
+        });
+    }
+
+    private TestResult createTestResult(final String name,
+                                        final String uid,
+                                        final String historyId,
+                                        final long start,
+                                        final long stop) {
+        return new TestResult()
+                .setName(name)
+                .setUid(uid)
+                .setHistoryId(historyId)
+                .setStatus(Status.BROKEN)
+                .setLabels(
+                        asList(
+                                LabelName.HOST.label("agent.local"),
+                                LabelName.THREAD.label("worker-1")
+                        )
+                )
+                .setTime(new Time().setStart(start).setStop(stop).setDuration(stop - start));
+    }
+
+    private JsonNode findByUid(final JsonNode node, final String uid) {
+        final JsonNode found = findByUidOrMissing(node, uid);
+        assertThat(found.isMissingNode())
+                .as("timeline node with uid %s", uid)
+                .isFalse();
+        return found;
+    }
+
+    private List<String> fieldNames(final JsonNode node) {
+        final List<String> names = new ArrayList<>();
+        node.fieldNames().forEachRemaining(names::add);
+        return names;
+    }
+
+    private JsonNode findByUidOrMissing(final JsonNode node, final String uid) {
+        if (uid.equals(node.path("uid").asText(null))) {
+            return node;
+        }
+
+        for (JsonNode child : node.path("children")) {
+            final JsonNode found = findByUidOrMissing(child, uid);
+            if (!found.isMissingNode()) {
+                return found;
+            }
+        }
+
+        return mapper.getNodeFactory().missingNode();
+    }
+}

--- a/allure-generator/tests/e2e/timeline.spec.mts
+++ b/allure-generator/tests/e2e/timeline.spec.mts
@@ -64,6 +64,45 @@ test.describe("Timeline", () => {
     await expect(page.locator(".brush .handle--e")).toBeVisible();
   });
 
+  test("renders retry results as status-colored hatched bars", async ({ page }) => {
+    await openReport(page, {
+      fixture: uiDemo.name,
+      mode: REPORT_MODES.DIRECTORY,
+      route: "timeline",
+    });
+
+    const retryLinks = page.locator(".timeline__plot a:has(.timeline__item_retry)");
+    await expect.poll(() => retryLinks.count()).toBeGreaterThan(0);
+
+    const retryBars = page.locator(".timeline__item_retry");
+    const retryCount = await retryBars.count();
+    for (let index = 0; index < retryCount; index += 1) {
+      const retryBar = retryBars.nth(index);
+      const className = (await retryBar.getAttribute("class")) || "";
+      const status = className.match(
+        /\btimeline__item_status_(failed|broken|passed|skipped|unknown)\b/u,
+      )?.[1];
+      expect(status, `retry bar ${index} keeps its status class`).toBeTruthy();
+
+      const fill = await retryBar.evaluate((node) => getComputedStyle(node).fill);
+      expect(fill).toContain(`timeline-retry-${status}`);
+    }
+
+    const regularFill = await page
+      .locator(".timeline__item:not(.timeline__item_retry)")
+      .first()
+      .evaluate((node) => getComputedStyle(node).fill);
+    expect(regularFill).not.toContain("timeline-retry-");
+
+    const firstRetryLink = retryLinks.first();
+    await expect(firstRetryLink).toHaveAttribute("href", /^#testresult\/.+$/);
+    await firstRetryLink.evaluate((node) => {
+      node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await expect.poll(() => currentRoute(page)).toMatch(/^testresult\/.+$/);
+    await expect(page.locator(".test-result__name")).toBeVisible();
+  });
+
   test("shows a loader and error splash when timeline data fails to load", async ({ page }) => {
     const gate = createDeferredGate();
 

--- a/allure-generator/tests/e2e/timeline.spec.mts
+++ b/allure-generator/tests/e2e/timeline.spec.mts
@@ -5,6 +5,30 @@ import { createDeferredGate } from "./support/async.mts";
 
 const uiDemo = fixtures.uiDemo;
 
+type TimelineNode = {
+  children?: TimelineNode[];
+  retry?: boolean;
+  time?: {
+    duration?: number;
+    start?: number;
+    stop?: number;
+  };
+};
+
+const makeFirstTimelineLeafZeroDuration = (node: TimelineNode): boolean => {
+  if (node.children) {
+    return node.children.some(makeFirstTimelineLeafZeroDuration);
+  }
+
+  if (node.retry || typeof node.time?.start !== "number" || typeof node.time.stop !== "number") {
+    return false;
+  }
+
+  node.time.stop = node.time.start;
+  node.time.duration = 0;
+  return true;
+};
+
 test.describe("Timeline", () => {
   test("filters visible results by duration and links bars to test results", async ({ page }) => {
     await openReport(page, {
@@ -97,6 +121,62 @@ test.describe("Timeline", () => {
     const firstRetryLink = retryLinks.first();
     await expect(firstRetryLink).toHaveAttribute("href", /^#testresult\/.+$/);
     await firstRetryLink.evaluate((node) => {
+      node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await expect.poll(() => currentRoute(page)).toMatch(/^testresult\/.+$/);
+    await expect(page.locator(".test-result__name")).toBeVisible();
+  });
+
+  test("renders zero-duration results as status-colored dots", async ({ page }) => {
+    await page.route(/\/data\/timeline\.json(?:\?.*)?$/, async (route) => {
+      const response = await route.fetch();
+      const timeline = (await response.json()) as TimelineNode;
+
+      if (!makeFirstTimelineLeafZeroDuration(timeline)) {
+        throw new Error("Expected the timeline fixture to contain at least one non-retry result");
+      }
+
+      await route.fulfill({ json: timeline, response });
+    });
+
+    await openReport(page, {
+      fixture: uiDemo.name,
+      mode: REPORT_MODES.DIRECTORY,
+      route: "timeline",
+    });
+
+    const zeroDots = page.locator("circle.timeline__item_zero");
+    await expect(zeroDots).toHaveCount(1);
+    await expect(page.locator("rect.timeline__item_zero")).toHaveCount(0);
+    await expect(page.locator("rect.timeline__item:not(.timeline__item_zero)")).not.toHaveCount(0);
+
+    const zeroDot = zeroDots.first();
+    const className = (await zeroDot.getAttribute("class")) || "";
+    const status = className.match(
+      /\btimeline__item_status_(failed|broken|passed|skipped|unknown)\b/u,
+    )?.[1];
+    expect(status, "zero-duration dot keeps its status class").toBeTruthy();
+
+    await expect(zeroDot).toHaveAttribute("r", "5");
+    await expect
+      .poll(async () => Number.isFinite(Number(await zeroDot.getAttribute("cx"))))
+      .toBe(true);
+
+    const zeroResultLink = page.locator(".timeline__plot a:has(circle.timeline__item_zero)").first();
+    await expect(zeroResultLink).toHaveAttribute("href", /^#testresult\/.+$/);
+    await expect
+      .poll(async () =>
+        zeroResultLink.evaluate((node) => {
+          const siblings = Array.from(node.parentElement?.children ?? []);
+          const dotIndex = siblings.indexOf(node);
+
+          return siblings
+            .slice(dotIndex + 1)
+            .every((sibling) => !sibling.querySelector("rect.timeline__item"));
+        }),
+      )
+      .toBe(true);
+    await zeroResultLink.evaluate((node) => {
       node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await expect.poll(() => currentRoute(page)).toMatch(/^testresult\/.+$/);


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The Timeline now makes every execution visible, including retry attempts and tests that finish with zero duration. Retried attempts are shown as status-colored hatched bars, while zero-duration results are shown as status-colored dots above regular bars, so reports no longer leave confusing gaps or invisible executions.

Timeline result links keep their normal navigation and tooltips, and now expose discernible labels for assistive technology. This improves retry-heavy reports and reports generated from timing formats where some results have no measurable duration.

fixes #1018 
fixes #1957 

<img width="1547" height="738" alt="Screenshot 2026-05-29 at 12 12 18" src="https://github.com/user-attachments/assets/9d9b2641-509f-4017-a51b-c66ea030ca9c" />

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2