### PR TITLE
Fix Windows launcher classpath

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,15 +79,22 @@ jobs:
     name: "Test Allure Commandline"
     runs-on: ${{ matrix.os }}
     needs: build
+    env:
+      ALLURE_TESTCMD_DUMP_NAME: allure-results-testcmd-${{ matrix.os }}-jdk-${{ matrix.java-version }}-${{ matrix.install.name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [ '8', '11', '17', '20' ]
-        commandline-path:
-          - .
-          - testcmd/install/allure-commandline-under-a-nested-working-directory/with-windows-launcher-classpath-length-regression/allure-commandline
+        install:
+          - name: regular
+            path: .
+          - name: nested
+            path: testcmd/install/allure-commandline-under-a-nested-working-directory/with-windows-launcher-classpath-length-regression/allure-commandline
     steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
       - name: Set up JRE ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
@@ -98,21 +105,42 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: allure-commandline
-          path: ${{ matrix.commandline-path }}
+          path: ${{ matrix.install.path }}
       - name: Download testcmd smoke results artifact
         uses: actions/download-artifact@v8
         with:
           name: testcmd-smoke-results
           path: testcmd-smoke-results
       - name: Add execute permissions to script
-        run: chmod +x ${{ matrix.commandline-path }}/bin/allure
+        run: chmod +x ${{ matrix.install.path }}/bin/allure
       - name: Run version command
-        run: ${{ matrix.commandline-path }}/bin/allure --version
+        shell: pwsh
+        run: |
+          $allure = '${{ matrix.install.path }}/bin/allure'
+          npx -y allure@3 check `
+            --name 'testcmd allure --version (${{ matrix.os }}, Java ${{ matrix.java-version }}, ${{ matrix.install.name }})' `
+            --tag testcmd `
+            --tag ${{ matrix.os }} `
+            --tag java-${{ matrix.java-version }} `
+            --tag ${{ matrix.install.name }} `
+            --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-version' `
+            -- pwsh -NoProfile -Command "& '$allure' --version"
       - name: Generate demo report
-        run: ${{ matrix.commandline-path }}/bin/allure generate testcmd-smoke-results
+        shell: pwsh
+        run: |
+          $allure = '${{ matrix.install.path }}/bin/allure'
+          npx -y allure@3 check `
+            --name 'testcmd allure generate (${{ matrix.os }}, Java ${{ matrix.java-version }}, ${{ matrix.install.name }})' `
+            --tag testcmd `
+            --tag ${{ matrix.os }} `
+            --tag java-${{ matrix.java-version }} `
+            --tag ${{ matrix.install.name }} `
+            --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-generate' `
+            -- pwsh -NoProfile -Command "& '$allure' generate testcmd-smoke-results"
       - name: Verify generated tree data
         shell: pwsh
         run: |
+          $verifyScript = @'
           $requiredFiles = @(
             'allure-report/data/behaviors.json',
             'allure-report/data/behaviors.csv',
@@ -132,6 +160,23 @@ jobs:
           $requiredFiles | ForEach-Object {
             Write-Host "Verified $_"
           }
+          '@
+
+          npx -y allure@3 check `
+            --name 'testcmd generated tree data (${{ matrix.os }}, Java ${{ matrix.java-version }}, ${{ matrix.install.name }})' `
+            --tag testcmd `
+            --tag ${{ matrix.os }} `
+            --tag java-${{ matrix.java-version }} `
+            --tag ${{ matrix.install.name }} `
+            --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-tree-data' `
+            -- pwsh -NoProfile -Command $verifyScript
+      - name: Upload Allure testcmd dump
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ALLURE_TESTCMD_DUMP_NAME }}
+          path: ./${{ env.ALLURE_TESTCMD_DUMP_NAME }}-*.zip
+          if-no-files-found: ignore
   report:
     needs: [build, testcmd]
     name: "Build report"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [ '8', '11', '17', '20' ]
+        commandline-path:
+          - .
+          - testcmd/install/allure-commandline-under-a-nested-working-directory/with-windows-launcher-classpath-length-regression/allure-commandline
     steps:
       - name: Set up JRE ${{ matrix.java-version }}
         uses: actions/setup-java@v5
@@ -95,17 +98,18 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: allure-commandline
+          path: ${{ matrix.commandline-path }}
       - name: Download testcmd smoke results artifact
         uses: actions/download-artifact@v8
         with:
           name: testcmd-smoke-results
           path: testcmd-smoke-results
       - name: Add execute permissions to script
-        run: chmod +x ./bin/allure
+        run: chmod +x ${{ matrix.commandline-path }}/bin/allure
       - name: Run version command
-        run: ./bin/allure --version
+        run: ${{ matrix.commandline-path }}/bin/allure --version
       - name: Generate demo report
-        run: ./bin/allure generate testcmd-smoke-results
+        run: ${{ matrix.commandline-path }}/bin/allure generate testcmd-smoke-results
       - name: Verify generated tree data
         shell: pwsh
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,7 +140,6 @@ jobs:
       - name: Verify generated tree data
         shell: pwsh
         run: |
-          $verifyScript = @'
           $requiredFiles = @(
             'allure-report/data/behaviors.json',
             'allure-report/data/behaviors.csv',
@@ -153,23 +152,34 @@ jobs:
           }
 
           if ($missingFiles.Count -gt 0) {
-            Write-Error "Missing generated report files: $($missingFiles -join ', ')"
+            $message = "Missing generated report files: $($missingFiles -join ', ')"
+            npx -y allure@3 check `
+              --name 'testcmd generated tree data (${{ matrix.os }}, Java ${{ matrix.java-version }}, ${{ matrix.install.name }})' `
+              --status failed `
+              --message $message `
+              --tag testcmd `
+              --tag ${{ matrix.os }} `
+              --tag java-${{ matrix.java-version }} `
+              --tag ${{ matrix.install.name }} `
+              --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-tree-data'
+            Write-Error $message
             exit 1
           }
 
           $requiredFiles | ForEach-Object {
             Write-Host "Verified $_"
           }
-          '@
 
+          $message = "Verified generated report files: $($requiredFiles -join ', ')"
           npx -y allure@3 check `
             --name 'testcmd generated tree data (${{ matrix.os }}, Java ${{ matrix.java-version }}, ${{ matrix.install.name }})' `
+            --status passed `
+            --message $message `
             --tag testcmd `
             --tag ${{ matrix.os }} `
             --tag java-${{ matrix.java-version }} `
             --tag ${{ matrix.install.name }} `
-            --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-tree-data' `
-            -- pwsh -NoProfile -Command $verifyScript
+            --dump '${{ env.ALLURE_TESTCMD_DUMP_NAME }}-tree-data'
       - name: Upload Allure testcmd dump
         if: always()
         uses: actions/upload-artifact@v7

--- a/allure-commandline/build.gradle.kts
+++ b/allure-commandline/build.gradle.kts
@@ -51,7 +51,20 @@ tasks.distTar {
 
 val startScripts by tasks.existing(CreateStartScripts::class) {
     applicationName = "allure"
-    classpath = files(tasks.jar) + configurations.runtimeClasspath.get() + files("src/lib/config")
+    classpath = files(tasks.jar) + configurations.runtimeClasspath.get() + files("src/dist/lib/config")
+    doLast {
+        val classpathLine = Regex("(?m)^set CLASSPATH=.*$")
+        val script = windowsScript.readText()
+        val matches = classpathLine.findAll(script).toList()
+
+        if (matches.size != 1) {
+            throw GradleException("Expected exactly one CLASSPATH line in ${windowsScript}, found ${matches.size}")
+        }
+
+        windowsScript.writeText(classpathLine.replace(script) {
+            "set CLASSPATH=%APP_HOME%\\lib\\*;%APP_HOME%\\lib\\config"
+        })
+    }
 }
 
 tasks.build {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

After allure-framework/allure2#3309, the generated Windows launcher for Allure Commandline uses an explicit jar-by-jar classpath instead of a short wildcard classpath.

In Allure Commandline 2.42.0, bin/allure.bat contains a single set CLASSPATH=... line that repeats %APP_HOME% once per jar. The current line is about 2127 chars before expansion and contains 51 %APP_HOME% entries.

On Windows, cmd.exe has an effective command line limit of 8191 characters. After %APP_HOME% expansion, the launcher can exceed that limit when Allure is installed under a long path.

Approximate formula for 2.42.0:
text
expanded_length = 1617 + 51 * length(APP_HOME)

So the launcher becomes risky once APP_HOME is around 129+ characters.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2