### PR TITLE
Harden XCTest plist parsing against external entities

### DIFF
--- a/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
+++ b/plugins/xctest-plugin/src/main/java/io/qameta/allure/xctest/XcTestPlugin.java
@@ -23,11 +23,19 @@ import io.qameta.allure.entity.Status;
 import io.qameta.allure.entity.Step;
 import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.entity.Time;
+import io.qameta.allure.parser.ClasspathEntityResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 import xmlwise.Plist;
+import xmlwise.XmlElement;
 import xmlwise.XmlParseException;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -77,12 +85,36 @@ public class XcTestPlugin implements Reader {
     private void readSummaries(final Path directory, final Path testSummariesPath, final ResultsVisitor visitor) {
         try {
             LOGGER.info("Parse file {}", testSummariesPath);
-            final Map<String, Object> loaded = Plist.load(testSummariesPath.toFile());
+            final Map<String, Object> loaded = loadPlist(testSummariesPath);
             final List<?> summaries = asList(loaded.getOrDefault(TESTABLE_SUMMARIES, emptyList()));
             summaries.forEach(summary -> parseSummary(directory, summary, visitor));
-        } catch (XmlParseException | IOException e) {
+        } catch (XmlParseException | SAXException | ParserConfigurationException | IOException e) {
             LOGGER.error("Could not parse file {}", testSummariesPath, e);
         }
+    }
+
+    private Map<String, Object> loadPlist(final Path testSummariesPath)
+            throws IOException, ParserConfigurationException, SAXException, XmlParseException {
+        final DocumentBuilderFactory factory = newDocumentBuilderFactory();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setEntityResolver(new ClasspathEntityResolver());
+
+        final Document document = builder.parse(testSummariesPath.toFile());
+        return Plist.fromXmlElement(new XmlElement(document.getDocumentElement()));
+    }
+
+    private DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setValidating(false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return factory;
     }
 
     private void parseSummary(final Path directory, final Object summary, final ResultsVisitor visitor) {

--- a/plugins/xctest-plugin/src/test/java/io/qameta/allure/xctest/XcTestPluginTest.java
+++ b/plugins/xctest-plugin/src/test/java/io/qameta/allure/xctest/XcTestPluginTest.java
@@ -20,6 +20,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.context.JacksonContext;
 import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.ResultsVisitor;
+import io.qameta.allure.entity.Step;
 import io.qameta.allure.entity.TestResult;
 import io.qameta.allure.entity.Time;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,8 @@ import static org.mockito.Mockito.when;
  * @author charlie (Dmitry Baev).
  */
 class XcTestPluginTest {
+
+    private static final String EXTERNAL_ENTITY_CONTENT = "TOPSECRET_XCTEST_LEAK_98765";
 
     private Configuration configuration;
     private ResultsVisitor visitor;
@@ -109,6 +112,35 @@ class XcTestPluginTest {
                         tuple("test_C1397()", Time.create(1494595230L, 1494627643L)),
                         tuple("test_C6925()", Time.create(1494595397L, 1494624364L))
                 );
+    }
+
+    /**
+     * Verifies XCTest plist parsing does not expand external entities from an internal DTD subset.
+     * The test checks file contents do not flow into parsed test or step names.
+     */
+    @Description
+    @Test
+    void shouldNotExpandExternalEntities() throws Exception {
+        final Path secret = Allure.step("Create external entity target file", () -> {
+            final Path target = resultsDirectory.resolve("secret.txt");
+            Files.write(target, EXTERNAL_ENTITY_CONTENT.getBytes(StandardCharsets.UTF_8));
+            Allure.addAttachment("external-entity-target.txt", "text/plain", EXTERNAL_ENTITY_CONTENT);
+            return target;
+        });
+        writePlist(resultsDirectory, "sample.plist", xxePlist(secret.toUri().toString()));
+
+        readResults(resultsDirectory);
+
+        final List<TestResult> results = captureTestResults(1);
+        Allure.addAttachment("external-entity-parsed-names.txt", "text/plain", describeResultAndStepNames(results));
+
+        assertThat(results)
+                .extracting(TestResult::getName)
+                .doesNotContain(EXTERNAL_ENTITY_CONTENT);
+        assertThat(results.get(0).getTestStage().getSteps())
+                .hasSize(1)
+                .extracting(Step::getName)
+                .doesNotContain(EXTERNAL_ENTITY_CONTENT);
     }
 
     /**
@@ -260,6 +292,16 @@ class XcTestPluginTest {
         });
     }
 
+    private Path writePlist(final Path directory, final String fileName, final String plist) throws IOException {
+        return Allure.step("Write plist fixture " + fileName, () -> {
+            final Path destination = directory.resolve(fileName);
+            Files.createDirectories(destination.getParent());
+            Files.write(destination, plist.getBytes(StandardCharsets.UTF_8));
+            Allure.addAttachment(fileName, "application/xml", plist, ".plist");
+            return destination;
+        });
+    }
+
     private List<TestResult> captureTestResults(final int expectedCount) {
         return Allure.step("Capture parsed XCTest test results", () -> {
             final ArgumentCaptor<TestResult> captor = ArgumentCaptor.forClass(TestResult.class);
@@ -319,6 +361,20 @@ class XcTestPluginTest {
         return builder.toString();
     }
 
+    private String describeResultAndStepNames(final List<TestResult> results) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("results=").append(results.size()).append(System.lineSeparator());
+        results.forEach(result -> {
+            builder.append("resultName=").append(result.getName()).append(System.lineSeparator());
+            result.getTestStage().getSteps()
+                    .forEach(step -> builder
+                            .append("stepName=")
+                            .append(step.getName())
+                            .append(System.lineSeparator()));
+        });
+        return builder.toString();
+    }
+
     private String describeAttachments(final List<Path> attachments) {
         final StringBuilder builder = new StringBuilder();
         builder.append("attachments=").append(attachments.size()).append(System.lineSeparator());
@@ -344,5 +400,47 @@ class XcTestPluginTest {
             return null;
         }
         return String.format("start=%s, stop=%s, duration=%s", time.getStart(), time.getStop(), time.getDuration());
+    }
+
+    private String xxePlist(final String entityUri) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE plist [\n"
+                + "  <!ENTITY xxe SYSTEM \"" + entityUri + "\">\n"
+                + "]>\n"
+                + "<plist version=\"1.0\">\n"
+                + "  <dict>\n"
+                + "    <key>TestableSummaries</key>\n"
+                + "    <array>\n"
+                + "      <dict>\n"
+                + "        <key>TestName</key>\n"
+                + "        <string>Suite</string>\n"
+                + "        <key>Tests</key>\n"
+                + "        <array>\n"
+                + "          <dict>\n"
+                + "            <key>TestName</key>\n"
+                + "            <string>&xxe;</string>\n"
+                + "            <key>TestIdentifier</key>\n"
+                + "            <string>XxeVerification/testExternalEntity()</string>\n"
+                + "            <key>TestStatus</key>\n"
+                + "            <string>Success</string>\n"
+                + "            <key>Duration</key>\n"
+                + "            <real>0.1</real>\n"
+                + "            <key>ActivitySummaries</key>\n"
+                + "            <array>\n"
+                + "              <dict>\n"
+                + "                <key>Title</key>\n"
+                + "                <string>&xxe;</string>\n"
+                + "                <key>StartTimeInterval</key>\n"
+                + "                <real>0.0</real>\n"
+                + "                <key>FinishTimeInterval</key>\n"
+                + "                <real>0.1</real>\n"
+                + "              </dict>\n"
+                + "            </array>\n"
+                + "          </dict>\n"
+                + "        </array>\n"
+                + "      </dict>\n"
+                + "    </array>\n"
+                + "  </dict>\n"
+                + "</plist>\n";
     }
 }

--- a/plugins/xctest-plugin/src/test/java/io/qameta/allure/xctest/XcTestPluginTest.java
+++ b/plugins/xctest-plugin/src/test/java/io/qameta/allure/xctest/XcTestPluginTest.java
@@ -367,10 +367,12 @@ class XcTestPluginTest {
         results.forEach(result -> {
             builder.append("resultName=").append(result.getName()).append(System.lineSeparator());
             result.getTestStage().getSteps()
-                    .forEach(step -> builder
-                            .append("stepName=")
-                            .append(step.getName())
-                            .append(System.lineSeparator()));
+                    .forEach(
+                            step -> builder
+                                    .append("stepName=")
+                                    .append(step.getName())
+                                    .append(System.lineSeparator())
+                    );
         });
         return builder.toString();
     }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

XCTest result imports no longer expand external entities declared in plist files. A crafted XCTest result could previously cause local file contents or internal HTTP responses to appear in generated test and step names when the report was built from an attacker-influenced results directory.

The XCTest reader now preserves normal Apple plist parsing while blocking external DTDs and external entity resolution. Regression coverage verifies that malicious `TestName` and activity `Title` entity references do not leak file contents into the generated Allure model.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2