### PR TITLE
Limit oversized attachment previews

### DIFF
--- a/allure-generator/src/main/javascript/features/attachments/model/previewLimits.mts
+++ b/allure-generator/src/main/javascript/features/attachments/model/previewLimits.mts
@@ -1,0 +1,31 @@
+import filesize from "../../../helpers/filesize.mts";
+import translate from "../../../helpers/t.mts";
+
+const MiB = 1024 * 1024;
+
+export const ATTACHMENT_PREVIEW_MAX_BYTES = 10 * MiB;
+const ATTACHMENT_TEXT_PROCESSING_MAX_BYTES = 2 * MiB;
+const ATTACHMENT_SYNTAX_HIGHLIGHT_MAX_BYTES = ATTACHMENT_TEXT_PROCESSING_MAX_BYTES;
+export const INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES = ATTACHMENT_TEXT_PROCESSING_MAX_BYTES;
+
+export const getTextByteLength = (content: string) => {
+  if (content.length > ATTACHMENT_PREVIEW_MAX_BYTES) {
+    return content.length;
+  }
+
+  return new Blob([content]).size;
+};
+
+export const isAttachmentPreviewOversized = (size: unknown) =>
+  typeof size === "number" && Number.isFinite(size) && size > ATTACHMENT_PREVIEW_MAX_BYTES;
+
+export const getAttachmentPreviewOversizeReason = () =>
+  translate("component.attachment.previewSizeExceeded", {
+    hash: {
+      size: filesize(ATTACHMENT_PREVIEW_MAX_BYTES),
+    },
+  });
+
+export const isSyntaxHighlightOversized = (content: string) =>
+  content.length > ATTACHMENT_SYNTAX_HIGHLIGHT_MAX_BYTES ||
+  new Blob([content]).size > ATTACHMENT_SYNTAX_HIGHLIGHT_MAX_BYTES;

--- a/allure-generator/src/main/javascript/features/attachments/views/BaseAttachmentPreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/BaseAttachmentPreviewView.mts
@@ -19,6 +19,7 @@ export type AttachmentPreviewOptions = {
   className?: string;
   codeLanguage?: string;
   htmlPreviewDisabledReason?: string | null;
+  previewDisabledReason?: string | null;
   previewData?: unknown;
   sourceUrl?: string | null;
 };

--- a/allure-generator/src/main/javascript/features/attachments/views/CodeAttachmentPreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/CodeAttachmentPreviewView.mts
@@ -1,6 +1,6 @@
 import "./CodeAttachmentPreviewView.scss";
 import b from "../../../shared/bem/index.mts";
-import highlight from "../../../utils/highlight.mts";
+import { highlightElement } from "../../../utils/highlight.mts";
 import {
   createDiv,
   createPre,
@@ -29,7 +29,7 @@ const renderLoadedCodeAttachmentPreviewView = ({
     codeBlock.classList.add(`language-${language}`);
   }
 
-  highlight.highlightElement(codeBlock);
+  highlightElement(codeBlock);
   textContainer.appendChild(codeBlock);
   return textContainer;
 };

--- a/allure-generator/src/main/javascript/features/attachments/views/FallbackAttachmentPreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/FallbackAttachmentPreviewView.mts
@@ -13,11 +13,17 @@ const renderFallbackAttachmentPreviewView = ({
   attachment,
   className,
   fullScreen,
+  previewDisabledReason,
   sourceUrl,
 }: AttachmentPreviewOptions) => {
   const fallbackContainer = createDiv(
     joinClassNames(b("attachment-preview", { fallback: true, fullscreen: fullScreen }), className),
   );
+  if (previewDisabledReason) {
+    const message = createDiv(b("attachment-preview", "preview-message"));
+    message.textContent = previewDisabledReason;
+    fallbackContainer.appendChild(message);
+  }
   fallbackContainer.appendChild(createDownloadAction(attachment, sourceUrl));
   return fallbackContainer;
 };

--- a/allure-generator/src/main/javascript/features/attachments/views/FallbackAttachmentPreviewView.scss
+++ b/allure-generator/src/main/javascript/features/attachments/views/FallbackAttachmentPreviewView.scss
@@ -16,6 +16,11 @@
   gap: gap(0.5);
 }
 
+.attachment-preview__preview-message {
+  color: var(--color-text-secondary);
+  margin-bottom: gap(1);
+}
+
 .attachment-preview__download-icon {
   flex: 0 0 auto;
 }

--- a/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.helpers.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.helpers.mts
@@ -1,7 +1,14 @@
-const MiB = 1024 * 1024;
+import filesize from "../../../helpers/filesize.mts";
+import translate from "../../../helpers/t.mts";
+import {
+  ATTACHMENT_PREVIEW_MAX_BYTES,
+  getTextByteLength,
+  isAttachmentPreviewOversized,
+} from "../model/previewLimits.mts";
 
-export const HTML_PREVIEW_MAX_BYTES = 10 * MiB;
-export const HTML_PREVIEW_SOURCE_MAX_BYTES = 2 * MiB;
+export { INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES } from "../model/previewLimits.mts";
+
+export const HTML_PREVIEW_MAX_BYTES = ATTACHMENT_PREVIEW_MAX_BYTES;
 export const HTML_PREVIEW_MIN_HEIGHT = 320;
 export const HTML_PREVIEW_INITIAL_HEIGHT = 480;
 export const HTML_PREVIEW_MAX_INLINE_HEIGHT = 1600;
@@ -28,20 +35,19 @@ const HTML_PREVIEW_CSP = [
 
 const HTML_LIKE_PATTERN = /<\/?[a-z][\s\S]*>/i;
 
-const formatMiB = (bytes: number) => `${Math.round(bytes / MiB)} MiB`;
-
-export const getHtmlPreviewByteLength = (content: string) => new Blob([content]).size;
+export const getHtmlPreviewByteLength = getTextByteLength;
 
 export const getHtmlPreviewOversizeReason = () =>
-  `HTML preview is disabled because the attachment is larger than ${formatMiB(
-    HTML_PREVIEW_MAX_BYTES,
-  )}.`;
+  translate("component.attachment.htmlPreviewSizeExceeded", {
+    hash: {
+      size: filesize(HTML_PREVIEW_MAX_BYTES),
+    },
+  });
 
 export const getHtmlPreviewInvalidReason = () =>
-  "HTML preview is disabled because the attachment does not look like HTML.";
+  translate("component.attachment.htmlPreviewInvalid");
 
-export const isHtmlPreviewOversized = (size: unknown) =>
-  typeof size === "number" && Number.isFinite(size) && size > HTML_PREVIEW_MAX_BYTES;
+export const isHtmlPreviewOversized = isAttachmentPreviewOversized;
 
 export const isRenderableHtmlPreview = (content: string) =>
   HTML_LIKE_PATTERN.test(content.replace(/^\uFEFF/, "").trim());

--- a/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.mts
@@ -24,7 +24,7 @@ import {
   HTML_PREVIEW_MAX_INLINE_HEIGHT,
   HTML_PREVIEW_MIN_HEIGHT,
   HTML_PREVIEW_RESIZE_MESSAGE_TYPE,
-  HTML_PREVIEW_SOURCE_MAX_BYTES,
+  INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES,
   isHtmlPreviewOversized,
   isRenderableHtmlPreview,
 } from "./HtmlAttachmentPreviewView.helpers.mts";
@@ -137,7 +137,7 @@ const HtmlFallbackAttachmentPreviewView = ({
   );
   htmlFallbackContainer.appendChild(htmlFallbackStatus);
 
-  if (htmlContent && getHtmlPreviewByteLength(htmlContent) <= HTML_PREVIEW_SOURCE_MAX_BYTES) {
+  if (htmlContent && getHtmlPreviewByteLength(htmlContent) <= INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES) {
     htmlFallbackContainer.appendChild(
       createPre(
         `${b("attachment-preview", "code")} ${b("attachment-preview", "html-source")}`,

--- a/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/HtmlAttachmentPreviewView.mts
@@ -137,7 +137,10 @@ const HtmlFallbackAttachmentPreviewView = ({
   );
   htmlFallbackContainer.appendChild(htmlFallbackStatus);
 
-  if (htmlContent && getHtmlPreviewByteLength(htmlContent) <= INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES) {
+  if (
+    htmlContent &&
+    getHtmlPreviewByteLength(htmlContent) <= INVALID_HTML_PREVIEW_SOURCE_MAX_BYTES
+  ) {
     htmlFallbackContainer.appendChild(
       createPre(
         `${b("attachment-preview", "code")} ${b("attachment-preview", "html-source")}`,

--- a/allure-generator/src/main/javascript/features/attachments/views/PreviewView.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/PreviewView.mts
@@ -1,6 +1,11 @@
 import { AttachmentPreviewView } from "../model/attachmentPreviewView.mts";
+import {
+  getAttachmentPreviewOversizeReason,
+  isAttachmentPreviewOversized,
+} from "../model/previewLimits.mts";
 import { CodeAttachmentPreviewView } from "./CodeAttachmentPreviewView.mts";
 import { FallbackAttachmentPreviewView } from "./FallbackAttachmentPreviewView.mts";
+import { getHtmlPreviewOversizeReason } from "./HtmlAttachmentPreviewView.helpers.mts";
 import { HtmlAttachmentPreviewView } from "./HtmlAttachmentPreviewView.mts";
 import { HttpAttachmentView } from "./HttpAttachmentView.mts";
 import { ImageAttachmentPreviewView } from "./ImageAttachmentPreviewView.mts";
@@ -29,7 +34,41 @@ const attachmentPreviewViews: Record<AttachmentPreviewView, AttachmentPreviewCom
   [AttachmentPreviewView.Video]: VideoAttachmentPreviewView,
 };
 
+const sizeLimitedPreviewViews = new Set<AttachmentPreviewView>([
+  AttachmentPreviewView.Code,
+  AttachmentPreviewView.Html,
+  // HTTP exchange is structured, but the current preview still fetches and parses the whole JSON payload.
+  AttachmentPreviewView.HttpExchange,
+  AttachmentPreviewView.ScreenDiff,
+  AttachmentPreviewView.Svg,
+  AttachmentPreviewView.Table,
+  AttachmentPreviewView.Text,
+  AttachmentPreviewView.Uri,
+]);
+
+const getPreviewDisabledReason = (options: Parameters<AttachmentPreviewComponent>[0]) => {
+  if (
+    !options.view ||
+    !sizeLimitedPreviewViews.has(options.view) ||
+    !isAttachmentPreviewOversized(options.attachment.size)
+  ) {
+    return null;
+  }
+
+  return options.view === AttachmentPreviewView.Html
+    ? getHtmlPreviewOversizeReason()
+    : getAttachmentPreviewOversizeReason();
+};
+
 export const PreviewView: AttachmentPreviewComponent = (options) => {
+  const previewDisabledReason = getPreviewDisabledReason(options);
+  if (previewDisabledReason) {
+    return FallbackAttachmentPreviewView({
+      ...options,
+      previewDisabledReason,
+    });
+  }
+
   const createPreviewView = options.view ? attachmentPreviewViews[options.view] : null;
 
   return (createPreviewView ?? FallbackAttachmentPreviewView)(options);

--- a/allure-generator/src/main/javascript/translations/am.json
+++ b/allure-generator/src/main/javascript/translations/am.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Սեղմեք կցված ֆայլը ներբեռնելու համար",
       "videoNotSupported": "Ձեր դիտարկիչը չի աջակցում video պիտակը",
-      "htmlPreviewTitle": "HTML կցված ֆայլի նախադիտում՝ {{name}}"
+      "htmlPreviewTitle": "HTML կցված ֆայլի նախադիտում՝ {{name}}",
+      "previewSizeExceeded": "Կցորդի նախադիտումն անջատված է, քանի որ կցորդը {{size}}-ից մեծ է։",
+      "htmlPreviewSizeExceeded": "HTML նախադիտումն անջատված է, քանի որ կցորդը {{size}}-ից մեծ է։",
+      "htmlPreviewInvalid": "HTML նախադիտումն անջատված է, քանի որ կցորդը HTML-ի նման չէ։"
     },
     "screenDiff": {
       "empty": "Տարբերությունների տվյալներ չկան",

--- a/allure-generator/src/main/javascript/translations/az.json
+++ b/allure-generator/src/main/javascript/translations/az.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Qoşmanı endirmək üçün klikləyin",
       "videoNotSupported": "Brauzeriniz video teqini dəstəkləmir",
-      "htmlPreviewTitle": "HTML qoşmasına önbaxış: {{name}}"
+      "htmlPreviewTitle": "HTML qoşmasına önbaxış: {{name}}",
+      "previewSizeExceeded": "Qoşmanın önizləməsi deaktiv edilib, çünki qoşma {{size}} ölçüsündən böyükdür.",
+      "htmlPreviewSizeExceeded": "HTML önizləməsi deaktiv edilib, çünki qoşma {{size}} ölçüsündən böyükdür.",
+      "htmlPreviewInvalid": "HTML önizləməsi deaktiv edilib, çünki qoşma HTML kimi görünmür."
     },
     "screenDiff": {
       "empty": "Fərq məlumatı yoxdur",

--- a/allure-generator/src/main/javascript/translations/br.json
+++ b/allure-generator/src/main/javascript/translations/br.json
@@ -69,7 +69,10 @@
     "attachment": {
       "download": "Clique para baixar o anexo",
       "videoNotSupported": "Seu navegador não suporta a tag de vídeo",
-      "htmlPreviewTitle": "Pré-visualização do anexo HTML: {{name}}"
+      "htmlPreviewTitle": "Pré-visualização do anexo HTML: {{name}}",
+      "previewSizeExceeded": "A pré-visualização do anexo está desativada porque o anexo é maior que {{size}}.",
+      "htmlPreviewSizeExceeded": "A pré-visualização HTML está desativada porque o anexo é maior que {{size}}.",
+      "htmlPreviewInvalid": "A pré-visualização HTML está desativada porque o anexo não parece ser HTML."
     },
     "screenDiff": {
       "empty": "Nenhum dado de diff fornecido",

--- a/allure-generator/src/main/javascript/translations/de.json
+++ b/allure-generator/src/main/javascript/translations/de.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Klicken, um den Anhang herunterzuladen",
       "videoNotSupported": "Ihr Browser unterstützt das Video-Tag nicht",
-      "htmlPreviewTitle": "HTML-Anhangsvorschau: {{name}}"
+      "htmlPreviewTitle": "HTML-Anhangsvorschau: {{name}}",
+      "previewSizeExceeded": "Die Anhangsvorschau ist deaktiviert, weil der Anhang größer als {{size}} ist.",
+      "htmlPreviewSizeExceeded": "Die HTML-Vorschau ist deaktiviert, weil der Anhang größer als {{size}} ist.",
+      "htmlPreviewInvalid": "Die HTML-Vorschau ist deaktiviert, weil der Anhang nicht wie HTML aussieht."
     },
     "screenDiff": {
       "empty": "Keine Diff-Daten vorhanden",

--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Click to download attachment",
       "videoNotSupported": "Your browser does not support the video tag",
-      "htmlPreviewTitle": "HTML attachment preview: {{name}}"
+      "htmlPreviewTitle": "HTML attachment preview: {{name}}",
+      "previewSizeExceeded": "Attachment preview is disabled because the attachment is larger than {{size}}.",
+      "htmlPreviewSizeExceeded": "HTML preview is disabled because the attachment is larger than {{size}}.",
+      "htmlPreviewInvalid": "HTML preview is disabled because the attachment does not look like HTML."
     },
     "screenDiff": {
       "empty": "No diff data provided",

--- a/allure-generator/src/main/javascript/translations/es.json
+++ b/allure-generator/src/main/javascript/translations/es.json
@@ -65,7 +65,10 @@
     "attachment": {
       "download": "Haz clic para descargar el adjunto",
       "videoNotSupported": "Tu navegador no admite la etiqueta de video",
-      "htmlPreviewTitle": "Vista previa del adjunto HTML: {{name}}"
+      "htmlPreviewTitle": "Vista previa del adjunto HTML: {{name}}",
+      "previewSizeExceeded": "La vista previa del adjunto está desactivada porque el adjunto supera {{size}}.",
+      "htmlPreviewSizeExceeded": "La vista previa HTML está desactivada porque el adjunto supera {{size}}.",
+      "htmlPreviewInvalid": "La vista previa HTML está desactivada porque el adjunto no parece HTML."
     },
     "screenDiff": {
       "empty": "No se proporcionaron datos de diferencias",

--- a/allure-generator/src/main/javascript/translations/fr.json
+++ b/allure-generator/src/main/javascript/translations/fr.json
@@ -65,7 +65,10 @@
     "attachment": {
       "download": "Cliquer pour télécharger la pièce jointe",
       "videoNotSupported": "Votre navigateur ne prend pas en charge la balise vidéo",
-      "htmlPreviewTitle": "Aperçu de la pièce jointe HTML : {{name}}"
+      "htmlPreviewTitle": "Aperçu de la pièce jointe HTML : {{name}}",
+      "previewSizeExceeded": "L'aperçu de la pièce jointe est désactivé, car la pièce jointe dépasse {{size}}.",
+      "htmlPreviewSizeExceeded": "L'aperçu HTML est désactivé, car la pièce jointe dépasse {{size}}.",
+      "htmlPreviewInvalid": "L'aperçu HTML est désactivé, car la pièce jointe ne ressemble pas à du HTML."
     },
     "screenDiff": {
       "empty": "Aucune donnée de comparaison fournie",

--- a/allure-generator/src/main/javascript/translations/he.json
+++ b/allure-generator/src/main/javascript/translations/he.json
@@ -65,7 +65,10 @@
     "attachment": {
       "download": "לחץ כדי להוריד את הקובץ המצורף",
       "videoNotSupported": "הדפדפן שלך אינו תומך בתגית הווידאו",
-      "htmlPreviewTitle": "תצוגה מקדימה של קובץ HTML מצורף: {{name}}"
+      "htmlPreviewTitle": "תצוגה מקדימה של קובץ HTML מצורף: {{name}}",
+      "previewSizeExceeded": "התצוגה המקדימה של הקובץ המצורף מושבתת כי הקובץ המצורף גדול מ-{{size}}.",
+      "htmlPreviewSizeExceeded": "התצוגה המקדימה של HTML מושבתת כי הקובץ המצורף גדול מ-{{size}}.",
+      "htmlPreviewInvalid": "התצוגה המקדימה של HTML מושבתת כי הקובץ המצורף לא נראה כמו HTML."
     },
     "screenDiff": {
       "empty": "לא סופקו נתוני diff",

--- a/allure-generator/src/main/javascript/translations/hu.json
+++ b/allure-generator/src/main/javascript/translations/hu.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Kattints a csatolmány letöltéséhez",
       "videoNotSupported": "A böngésződ nem támogatja a video taget",
-      "htmlPreviewTitle": "HTML csatolmány előnézete: {{name}}"
+      "htmlPreviewTitle": "HTML csatolmány előnézete: {{name}}",
+      "previewSizeExceeded": "A melléklet előnézete le van tiltva, mert a melléklet nagyobb, mint {{size}}.",
+      "htmlPreviewSizeExceeded": "A HTML előnézet le van tiltva, mert a melléklet nagyobb, mint {{size}}.",
+      "htmlPreviewInvalid": "A HTML előnézet le van tiltva, mert a melléklet nem tűnik HTML-nek."
     },
     "screenDiff": {
       "empty": "Nincs megadva eltérésadat",

--- a/allure-generator/src/main/javascript/translations/isv.json
+++ b/allure-generator/src/main/javascript/translations/isv.json
@@ -71,7 +71,10 @@
     "attachment": {
       "download": "Klikni za daunlod prilogy",
       "videoNotSupported": "Tvoj browser ne podpira video tag",
-      "htmlPreviewTitle": "Prědgled HTML prilogy: {{name}}"
+      "htmlPreviewTitle": "Prědgled HTML prilogy: {{name}}",
+      "previewSizeExceeded": "Pregled prilogy jest izključeny, zato že priloga jest večša od {{size}}.",
+      "htmlPreviewSizeExceeded": "HTML pregled jest izključeny, zato že priloga jest večša od {{size}}.",
+      "htmlPreviewInvalid": "HTML pregled jest izključeny, zato že priloga ne vygląda kako HTML."
     },
     "screenDiff": {
       "empty": "Nisu podane dannye razlike",

--- a/allure-generator/src/main/javascript/translations/it.json
+++ b/allure-generator/src/main/javascript/translations/it.json
@@ -65,7 +65,10 @@
     "attachment": {
       "download": "Fai clic per scaricare l'allegato",
       "videoNotSupported": "Il tuo browser non supporta il tag video",
-      "htmlPreviewTitle": "Anteprima allegato HTML: {{name}}"
+      "htmlPreviewTitle": "Anteprima allegato HTML: {{name}}",
+      "previewSizeExceeded": "L'anteprima dell'allegato è disattivata perché l'allegato è più grande di {{size}}.",
+      "htmlPreviewSizeExceeded": "L'anteprima HTML è disattivata perché l'allegato è più grande di {{size}}.",
+      "htmlPreviewInvalid": "L'anteprima HTML è disattivata perché l'allegato non sembra HTML."
     },
     "screenDiff": {
       "empty": "Nessun dato di diff fornito",

--- a/allure-generator/src/main/javascript/translations/ja.json
+++ b/allure-generator/src/main/javascript/translations/ja.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "クリックして添付ファイルをダウンロード",
       "videoNotSupported": "お使いのブラウザーは video タグをサポートしていません",
-      "htmlPreviewTitle": "HTML 添付ファイルのプレビュー: {{name}}"
+      "htmlPreviewTitle": "HTML 添付ファイルのプレビュー: {{name}}",
+      "previewSizeExceeded": "添付ファイルが {{size}} を超えているため、プレビューは無効です。",
+      "htmlPreviewSizeExceeded": "添付ファイルが {{size}} を超えているため、HTML プレビューは無効です。",
+      "htmlPreviewInvalid": "添付ファイルが HTML のように見えないため、HTML プレビューは無効です。"
     },
     "screenDiff": {
       "empty": "差分データがありません",

--- a/allure-generator/src/main/javascript/translations/ka.json
+++ b/allure-generator/src/main/javascript/translations/ka.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "მიმაგრებული ფაილის ჩამოსატვირთად დააწკაპუნე",
       "videoNotSupported": "თქვენი ბრაუზერი video ტეგს არ უჭერს მხარს",
-      "htmlPreviewTitle": "HTML მიმაგრებული ფაილის წინასწარი ნახვა: {{name}}"
+      "htmlPreviewTitle": "HTML მიმაგრებული ფაილის წინასწარი ნახვა: {{name}}",
+      "previewSizeExceeded": "დანართის წინასწარი ნახვა გამორთულია, რადგან დანართი {{size}}-ზე დიდია.",
+      "htmlPreviewSizeExceeded": "HTML-ის წინასწარი ნახვა გამორთულია, რადგან დანართი {{size}}-ზე დიდია.",
+      "htmlPreviewInvalid": "HTML-ის წინასწარი ნახვა გამორთულია, რადგან დანართი HTML-ს არ ჰგავს."
     },
     "screenDiff": {
       "empty": "განსხვავების მონაცემები არ არის მოწოდებული",

--- a/allure-generator/src/main/javascript/translations/kr.json
+++ b/allure-generator/src/main/javascript/translations/kr.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "첨부 파일을 다운로드하려면 클릭",
       "videoNotSupported": "브라우저가 video 태그를 지원하지 않습니다",
-      "htmlPreviewTitle": "HTML 첨부 파일 미리보기: {{name}}"
+      "htmlPreviewTitle": "HTML 첨부 파일 미리보기: {{name}}",
+      "previewSizeExceeded": "첨부 파일이 {{size}}보다 커서 미리보기가 비활성화되었습니다.",
+      "htmlPreviewSizeExceeded": "첨부 파일이 {{size}}보다 커서 HTML 미리보기가 비활성화되었습니다.",
+      "htmlPreviewInvalid": "첨부 파일이 HTML처럼 보이지 않아 HTML 미리보기가 비활성화되었습니다."
     },
     "screenDiff": {
       "empty": "차이 데이터가 제공되지 않았습니다",

--- a/allure-generator/src/main/javascript/translations/nl.json
+++ b/allure-generator/src/main/javascript/translations/nl.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Klik om de bijlage te downloaden",
       "videoNotSupported": "Je browser ondersteunt de videotag niet",
-      "htmlPreviewTitle": "Voorbeeld van HTML-bijlage: {{name}}"
+      "htmlPreviewTitle": "Voorbeeld van HTML-bijlage: {{name}}",
+      "previewSizeExceeded": "De bijlagevoorvertoning is uitgeschakeld omdat de bijlage groter is dan {{size}}.",
+      "htmlPreviewSizeExceeded": "De HTML-voorvertoning is uitgeschakeld omdat de bijlage groter is dan {{size}}.",
+      "htmlPreviewInvalid": "De HTML-voorvertoning is uitgeschakeld omdat de bijlage niet op HTML lijkt."
     },
     "screenDiff": {
       "empty": "Geen diffgegevens opgegeven",

--- a/allure-generator/src/main/javascript/translations/pl.json
+++ b/allure-generator/src/main/javascript/translations/pl.json
@@ -71,7 +71,10 @@
     "attachment": {
       "download": "Kliknij, aby pobrać załącznik",
       "videoNotSupported": "Twoja przeglądarka nie obsługuje tagu video",
-      "htmlPreviewTitle": "Podgląd załącznika HTML: {{name}}"
+      "htmlPreviewTitle": "Podgląd załącznika HTML: {{name}}",
+      "previewSizeExceeded": "Podgląd załącznika jest wyłączony, ponieważ załącznik jest większy niż {{size}}.",
+      "htmlPreviewSizeExceeded": "Podgląd HTML jest wyłączony, ponieważ załącznik jest większy niż {{size}}.",
+      "htmlPreviewInvalid": "Podgląd HTML jest wyłączony, ponieważ załącznik nie wygląda jak HTML."
     },
     "screenDiff": {
       "empty": "Nie podano danych różnic",

--- a/allure-generator/src/main/javascript/translations/ru.json
+++ b/allure-generator/src/main/javascript/translations/ru.json
@@ -71,7 +71,10 @@
     "attachment": {
       "download": "Нажмите, чтобы скачать вложение",
       "videoNotSupported": "Ваш браузер не поддерживает тег video",
-      "htmlPreviewTitle": "Предпросмотр HTML-вложения: {{name}}"
+      "htmlPreviewTitle": "Предпросмотр HTML-вложения: {{name}}",
+      "previewSizeExceeded": "Предпросмотр вложения отключен, потому что вложение больше {{size}}.",
+      "htmlPreviewSizeExceeded": "Предпросмотр HTML отключен, потому что вложение больше {{size}}.",
+      "htmlPreviewInvalid": "Предпросмотр HTML отключен, потому что вложение не похоже на HTML."
     },
     "screenDiff": {
       "empty": "Данные различий не предоставлены",

--- a/allure-generator/src/main/javascript/translations/sv.json
+++ b/allure-generator/src/main/javascript/translations/sv.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Klicka för att ladda ner bilagan",
       "videoNotSupported": "Din webbläsare stöder inte video-taggen",
-      "htmlPreviewTitle": "Förhandsvisning av HTML-bilaga: {{name}}"
+      "htmlPreviewTitle": "Förhandsvisning av HTML-bilaga: {{name}}",
+      "previewSizeExceeded": "Förhandsvisningen av bilagan är inaktiverad eftersom bilagan är större än {{size}}.",
+      "htmlPreviewSizeExceeded": "HTML-förhandsvisningen är inaktiverad eftersom bilagan är större än {{size}}.",
+      "htmlPreviewInvalid": "HTML-förhandsvisningen är inaktiverad eftersom bilagan inte ser ut som HTML."
     },
     "screenDiff": {
       "empty": "Inga diffdata angivna",

--- a/allure-generator/src/main/javascript/translations/tr.json
+++ b/allure-generator/src/main/javascript/translations/tr.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "Eki indirmek için tıkla",
       "videoNotSupported": "Tarayıcınız video etiketini desteklemiyor",
-      "htmlPreviewTitle": "HTML eki önizlemesi: {{name}}"
+      "htmlPreviewTitle": "HTML eki önizlemesi: {{name}}",
+      "previewSizeExceeded": "Ek önizlemesi, ek {{size}} boyutundan büyük olduğu için devre dışı bırakıldı.",
+      "htmlPreviewSizeExceeded": "HTML önizlemesi, ek {{size}} boyutundan büyük olduğu için devre dışı bırakıldı.",
+      "htmlPreviewInvalid": "HTML önizlemesi, ek HTML gibi görünmediği için devre dışı bırakıldı."
     },
     "screenDiff": {
       "empty": "Fark verisi sağlanmadı",

--- a/allure-generator/src/main/javascript/translations/zh.json
+++ b/allure-generator/src/main/javascript/translations/zh.json
@@ -63,7 +63,10 @@
     "attachment": {
       "download": "点击下载附件",
       "videoNotSupported": "你的浏览器不支持 video 标签",
-      "htmlPreviewTitle": "HTML 附件预览：{{name}}"
+      "htmlPreviewTitle": "HTML 附件预览：{{name}}",
+      "previewSizeExceeded": "附件大于 {{size}}，因此已禁用附件预览。",
+      "htmlPreviewSizeExceeded": "附件大于 {{size}}，因此已禁用 HTML 预览。",
+      "htmlPreviewInvalid": "附件看起来不像 HTML，因此已禁用 HTML 预览。"
     },
     "screenDiff": {
       "empty": "未提供差异数据",

--- a/allure-generator/src/main/javascript/utils/highlight.mts
+++ b/allure-generator/src/main/javascript/utils/highlight.mts
@@ -4,6 +4,7 @@ import diff from "highlight.js/lib/languages/diff";
 import json from "highlight.js/lib/languages/json";
 import md from "highlight.js/lib/languages/markdown";
 import xml from "highlight.js/lib/languages/xml";
+import { isSyntaxHighlightOversized } from "../features/attachments/model/previewLimits.mts";
 
 highlight.registerLanguage("xml", xml);
 highlight.registerLanguage("bash", bash);
@@ -11,4 +12,13 @@ highlight.registerLanguage("markdown", md);
 highlight.registerLanguage("diff", diff);
 highlight.registerLanguage("json", json);
 
-export default highlight;
+export const highlightElement = (element: HTMLElement) => {
+  const content = element.textContent || "";
+  if (isSyntaxHighlightOversized(content)) {
+    element.dataset.syntaxHighlightSkipped = "true";
+    return false;
+  }
+
+  highlight.highlightElement(element);
+  return true;
+};

--- a/allure-generator/tests/e2e/attachments.spec.mts
+++ b/allure-generator/tests/e2e/attachments.spec.mts
@@ -5,6 +5,8 @@ import { openCaseFromTree } from "./support/report.mts";
 import { previewContainerFor } from "./support/ui.mts";
 
 const attachmentsFixture = fixtures.attachments;
+const ATTACHMENT_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
+const ATTACHMENT_SYNTAX_HIGHLIGHT_MAX_BYTES = 2 * 1024 * 1024;
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -114,13 +116,17 @@ test.describe("Generic Attachments", () => {
     );
   });
 
-  test("does not fetch live HTML previews when attachment metadata exceeds the size cap", async ({
+  test("does not fetch oversized attachment previews when metadata exceeds the size cap", async ({
     page,
   }) => {
-    let htmlAttachmentFetches = 0;
+    const fetchedPreviewAttachments: string[] = [];
+    const oversizedPreviewSources = new Set<string>();
 
-    await page.route(/\/data\/attachments\/.*\.html(?:\?.*)?$/, async (route) => {
-      htmlAttachmentFetches += 1;
+    await page.route(/\/data\/attachments\/[^/]+(?:\?.*)?$/, async (route) => {
+      const source = new URL(route.request().url()).pathname.split("/").pop() || "";
+      if (oversizedPreviewSources.has(source)) {
+        fetchedPreviewAttachments.push(source);
+      }
       await route.continue();
     });
     await page.route(/\/data\/test-cases\/.*\.json(?:\?.*)?$/, async (route) => {
@@ -129,7 +135,7 @@ test.describe("Generic Attachments", () => {
 
       if (payload.name === attachmentsFixture.caseName) {
         type TestStageNode = {
-          attachments?: { name?: string; size?: number }[];
+          attachments?: { name?: string; size?: number; source?: string }[];
           steps?: TestStageNode[];
         };
 
@@ -139,8 +145,15 @@ test.describe("Generic Attachments", () => {
           }
 
           node.attachments?.forEach((attachment) => {
-            if (attachment.name === attachmentsFixture.attachments.htmlInteractive) {
-              attachment.size = 10 * 1024 * 1024 + 1;
+            if (
+              attachment.name === attachmentsFixture.attachments.htmlInteractive ||
+              attachment.name === attachmentsFixture.attachments.json ||
+              attachment.name === attachmentsFixture.attachments.http
+            ) {
+              attachment.size = ATTACHMENT_PREVIEW_MAX_BYTES + 1;
+              if (attachment.source) {
+                oversizedPreviewSources.add(attachment.source);
+              }
             }
           });
           node.steps?.forEach(updateAttachments);
@@ -172,7 +185,106 @@ test.describe("Generic Attachments", () => {
     await expect(preview.locator(".attachment-preview__html-message")).toHaveText(
       "HTML preview is disabled because the attachment is larger than 10 MiB.",
     );
-    expect(htmlAttachmentFetches).toBe(0);
+
+    const jsonRow = attachmentRow(page, attachmentsFixture.attachments.json);
+    await expect(jsonRow).toBeVisible();
+    await jsonRow.click();
+
+    const jsonPreview = previewContainerFor(jsonRow);
+    await expect(jsonPreview.locator(".attachment-preview__code")).toHaveCount(0);
+    await expect(jsonPreview.locator(".attachment-preview__preview-message")).toHaveText(
+      "Attachment preview is disabled because the attachment is larger than 10 MiB.",
+    );
+
+    const httpRow = attachmentRow(page, attachmentsFixture.attachments.http);
+    await expect(httpRow).toBeVisible();
+    await httpRow.click();
+
+    const httpPreview = previewContainerFor(httpRow);
+    await expect(httpPreview.locator(".http-attachment__summary")).toHaveCount(0);
+    await expect(httpPreview.locator(".attachment-preview__preview-message")).toHaveText(
+      "Attachment preview is disabled because the attachment is larger than 10 MiB.",
+    );
+
+    expect(fetchedPreviewAttachments).toEqual([]);
+  });
+
+  test("keeps media previews when metadata exceeds the generic preview cap", async ({ page }) => {
+    await page.route(/\/data\/test-cases\/.*\.json(?:\?.*)?$/, async (route) => {
+      const response = await route.fetch();
+      const payload = await response.json();
+
+      if (payload.name === attachmentsFixture.caseName) {
+        type TestStageNode = {
+          attachments?: { name?: string; size?: number }[];
+          steps?: TestStageNode[];
+        };
+
+        const updateAttachments = (node?: TestStageNode) => {
+          if (!node) {
+            return;
+          }
+
+          node.attachments?.forEach((attachment) => {
+            if (attachment.name === attachmentsFixture.attachments.png) {
+              attachment.size = ATTACHMENT_PREVIEW_MAX_BYTES + 1;
+            }
+          });
+          node.steps?.forEach(updateAttachments);
+        };
+
+        updateAttachments(payload.testStage);
+      }
+
+      await route.fulfill({
+        response,
+        body: JSON.stringify(payload),
+        contentType: "application/json",
+      });
+    });
+
+    await openCaseFromTree(page, {
+      fixture: attachmentsFixture.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: attachmentsFixture.caseName,
+    });
+
+    const pngRow = attachmentRow(page, attachmentsFixture.attachments.png);
+    await expect(pngRow).toBeVisible();
+    await pngRow.click();
+
+    const pngPreview = previewContainerFor(pngRow);
+    await expectImageToDecode(pngPreview.locator(".attachment-preview__media"));
+    await expect(pngPreview.locator(".attachment-preview__preview-message")).toHaveCount(0);
+  });
+
+  test("skips syntax highlighting for large code attachment previews", async ({ page }) => {
+    const largeJson = `{"payload":"${"x".repeat(ATTACHMENT_SYNTAX_HIGHLIGHT_MAX_BYTES + 1)}"}`;
+
+    await page.route(/\/data\/attachments\/.*\.json(?:\?.*)?$/, async (route) => {
+      await route.fulfill({
+        body: largeJson,
+        contentType: "application/json",
+      });
+    });
+
+    await openCaseFromTree(page, {
+      fixture: attachmentsFixture.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: attachmentsFixture.caseName,
+    });
+
+    const jsonRow = attachmentRow(page, attachmentsFixture.attachments.json);
+    await expect(jsonRow).toBeVisible();
+    await jsonRow.click();
+
+    const codeBlock = previewContainerFor(jsonRow).locator(".attachment-preview__code");
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock).toHaveClass(/language-json/);
+    await expect(codeBlock).toHaveAttribute("data-syntax-highlight-skipped", "true");
+    await expect(codeBlock).not.toHaveClass(/hljs/);
   });
 
   test("renders code and table attachment viewers", async ({ page }) => {

--- a/allure-generator/tests/e2e/attachments.spec.mts
+++ b/allure-generator/tests/e2e/attachments.spec.mts
@@ -182,7 +182,7 @@ test.describe("Generic Attachments", () => {
 
     const preview = previewContainerFor(htmlRow);
     await expect(preview.locator(".attachment-preview__frame")).toHaveCount(0);
-    await expect(preview.locator(".attachment-preview__html-message")).toHaveText(
+    await expect(preview.locator(".attachment-preview__preview-message")).toHaveText(
       "HTML preview is disabled because the attachment is larger than 10 MiB.",
     );
 

--- a/allure-generator/tests/e2e/playwright-trace.spec.mts
+++ b/allure-generator/tests/e2e/playwright-trace.spec.mts
@@ -4,6 +4,7 @@ import { openCaseFromTree } from "./support/report.mts";
 import { previewContainerFor, stepLocator } from "./support/ui.mts";
 
 const playwrightTrace = fixtures.playwrightTrace;
+const ATTACHMENT_PREVIEW_MAX_BYTES = 10 * 1024 * 1024;
 
 const expandStep = async (page: Page, title: string): Promise<Locator> => {
   const step = stepLocator(page, title);
@@ -78,6 +79,65 @@ test.describe("Playwright Trace", () => {
       }
     });
   }
+
+  test("does not apply the generic preview size limit to trace attachments", async ({ page }) => {
+    await page.route(/\/data\/test-cases\/.*\.json(?:\?.*)?$/, async (route) => {
+      const response = await route.fetch();
+      const payload = await response.json();
+
+      if (payload.name === playwrightTrace.caseName) {
+        type TestStageNode = {
+          attachments?: { name?: string; size?: number }[];
+          steps?: TestStageNode[];
+        };
+
+        const updateTraceAttachment = (node?: TestStageNode) => {
+          if (!node) {
+            return;
+          }
+
+          node.attachments?.forEach((attachment) => {
+            if (attachment.name === playwrightTrace.attachmentName) {
+              attachment.size = ATTACHMENT_PREVIEW_MAX_BYTES + 1;
+            }
+          });
+          node.steps?.forEach(updateTraceAttachment);
+        };
+
+        updateTraceAttachment(payload.testStage);
+      }
+
+      await route.fulfill({
+        response,
+        body: JSON.stringify(payload),
+        contentType: "application/json",
+      });
+    });
+
+    await openCaseFromTree(page, {
+      fixture: playwrightTrace.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: playwrightTrace.caseName,
+    });
+
+    const traceRow = (await expandStep(page, playwrightTrace.stepName)).locator(".attachment-row", {
+      hasText: playwrightTrace.attachmentName,
+    });
+
+    await traceRow.click();
+    await expect(page).toHaveURL(/attachment=/);
+    await expect(
+      previewContainerFor(traceRow).locator(".attachment-preview__preview-message"),
+    ).toHaveCount(0);
+
+    const traceFrame = page.locator(".modal__content #pw-trace-iframe");
+    const downloadLink = page.locator(".modal__title .attachment-preview__trace-download");
+
+    await expect(traceFrame).toBeVisible();
+    await expect(downloadLink).toBeVisible();
+    await expect(downloadLink).toHaveAttribute("download", /\.zip$/);
+  });
 
   test("loads the trace content on the first modal open in directory reports", async ({ page }) => {
     await openCaseFromTree(page, {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure Report now disables inline previews over 10 MiB for text-like and fully parsed attachment views: HTML, code, plain text, tables, URI lists, SVG, screen diffs, and HTTP exchange attachments. When one of these previews is too large, the report shows a translated fallback message with a download action instead of loading the full preview into the page.

Syntax highlighting is also skipped for code blocks over 2 MiB, and invalid HTML attachments only show their raw source fallback when that source is 2 MiB or smaller. Image and video previews are not capped by this change, and Playwright trace attachments continue using their dedicated viewer flow.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2