### PR TITLE
Make tree search match the package path of the test result (fixes #1077)

### DIFF
--- a/allure-generator/src/main/javascript/features/tree/model/filter.mts
+++ b/allure-generator/src/main/javascript/features/tree/model/filter.mts
@@ -40,6 +40,8 @@ const byText = (text?: string): TreeFilter => {
     return (
       !normalizedText ||
       String(child.name).toLowerCase().indexOf(normalizedText) > -1 ||
+      (typeof child.searchPath === "string" &&
+        child.searchPath.toLowerCase().indexOf(normalizedText) > -1) ||
       Boolean(child.children?.some(byText(normalizedText)))
     );
   };

--- a/allure-generator/src/main/javascript/features/tree/model/treeData.mts
+++ b/allure-generator/src/main/javascript/features/tree/model/treeData.mts
@@ -149,21 +149,25 @@ const createLeafOrderMap = (children: TreeNode[] = []) => {
   return new Map(sortedLeaves.map((leaf, index) => [leaf, index + 1]));
 };
 
-const normalizeNodes = (children: TreeNode[] = []): TreeNode[] => {
+const normalizeNodes = (children: TreeNode[] = [], parentPath = ""): TreeNode[] => {
   const leafOrders = createLeafOrderMap(children);
 
   return children.map((child) => {
+    const searchPath = [parentPath, child.name].filter(Boolean).join(".");
+
     if (!child.children) {
       return {
         ...child,
+        searchPath,
         order: leafOrders.get(child),
       };
     }
 
-    const normalizedChildren = normalizeNodes(child.children);
+    const normalizedChildren = normalizeNodes(child.children, searchPath);
 
     return {
       ...child,
+      searchPath,
       children: normalizedChildren,
       statistic: calculateStatistic(normalizedChildren),
       time: calculateTime(normalizedChildren),

--- a/allure-generator/src/main/javascript/types/report.mts
+++ b/allure-generator/src/main/javascript/types/report.mts
@@ -99,6 +99,7 @@ export type TestResult = {
 
 export type TreeNode = {
   name?: string;
+  searchPath?: string;
   uid?: string;
   parentUid?: string;
   status?: Status;

--- a/allure-generator/tests/e2e/support/fixtures.mts
+++ b/allure-generator/tests/e2e/support/fixtures.mts
@@ -40,6 +40,8 @@ export const fixtures = {
     packages: {
       root: "io.qameta.allure",
       className: "PullRequestsWebTest",
+      methodName: "shouldClosePullRequest",
+      pathQuery: "qameta.allure.PullRequestsWebTest.shouldClose",
     },
     widgets: {
       behaviors: "Features by stories",

--- a/allure-generator/tests/e2e/tree.shared.spec.mts
+++ b/allure-generator/tests/e2e/tree.shared.spec.mts
@@ -23,6 +23,11 @@ for (const mode of reportModes) {
       await searchInput.fill("tag:sm");
       await expect(page.locator(".tree__empty")).toHaveText("There are no items");
 
+      await searchInput.fill("allure.PullRequestsWebTest");
+      await expect(
+        page.locator(".node__leaf", { hasText: uiDemo.cases.failedPullRequest }),
+      ).toBeVisible();
+
       await searchInput.fill(uiDemo.cases.failedPullRequest);
       await expect(
         page.locator(".node__leaf", { hasText: uiDemo.cases.failedPullRequest }),
@@ -133,6 +138,19 @@ for (const mode of reportModes) {
       await groupLocator(page, uiDemo.packages.root).locator(":scope > .node__title").click();
       await expect(groupLocator(page, uiDemo.packages.className)).toBeVisible();
       await expect(page.locator(".tree__download")).toHaveCount(0);
+
+      const packagesSearchInput = page.locator(".search__input");
+      await packagesSearchInput.fill(uiDemo.packages.pathQuery);
+      await expect(groupLocator(page, uiDemo.packages.className)).toBeVisible();
+      await expect(
+        page.locator(".node__leaf", { hasText: uiDemo.packages.methodName }),
+      ).toBeVisible();
+
+      await packagesSearchInput.fill(uiDemo.packages.root);
+      await expect(
+        page.locator(".node__leaf", { hasText: uiDemo.packages.methodName }),
+      ).toBeVisible();
+      await packagesSearchInput.fill("");
     });
 
     test("collapsed groups stay collapsed when selecting leaves in other groups", async ({


### PR DESCRIPTION
<!-- PR title: Make tree search match the package path of the test result (fixes #1077) -->

### Context

Searching on the Packages tab cannot find tests by their package path (fixes #1077).

Two things break it today:

1. The tree text filter only matches the displayed node `name`. In the Packages tab the group names are dot-collapsed package segments (e.g. `io.qameta.allure` → `PullRequestsWebTest`), so a query that spans segment boundaries (e.g. `allure.PullRequestsWebTest` or a full package path) matches no node name at all.
2. Even when a query does match a group name, the bottom-up tree projection has already dropped all of the group's non-matching leaves, and the resulting empty group is then hidden by the status filter (`byStatuses` requires `children.length > 0`) — so the user ends up with no results whatsoever.

This change computes a `searchPath` for every tree node during normalization (`normalizeNodes`) — the dot-joined names of the node's ancestors plus its own name — and lets the tree text filter (`byText`) match it. A query for a package, a class, or any dotted-path substring now matches the leaves themselves, so the package is shown together with its tests. The fix is frontend-only and works for every data source, since the path is derived from the tree structure itself. The display is unchanged — `searchPath` is only consulted by the search.

Since `byText` is shared tree plumbing, searching a group name on the Suites/Behaviors/Categories tabs now also reveals the tests inside that group instead of showing nothing, which matches the expectation described in the issue.

Tests: Playwright e2e cases in `tree.shared.spec.mts` — searching across collapsed package segments and by root package on the Packages tab, and searching a suite (class) name on the Suites tab. All three assertions fail without this fix.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
