### PR TITLE
Fix plain text values being treated as relative URLs

### DIFF
--- a/allure-generator/src/main/javascript/shared/url.mts
+++ b/allure-generator/src/main/javascript/shared/url.mts
@@ -44,8 +44,7 @@ const isRelativeUrl = (value: string) => {
     value.startsWith("?") ||
     value.startsWith("/") ||
     value.startsWith("./") ||
-    value.startsWith("../") ||
-    !value.startsWith("\\")
+    value.startsWith("../") 
   );
 };
 


### PR DESCRIPTION
## Description

Fixes an issue where plain-text parameter values were incorrectly treated as relative URLs and rendered as clickable links.

## Changes

- Removed the catch-all relative URL condition from `isRelativeUrl`.
- Plain-text values are now rendered as normal text.

## Verification

Ran:

- npm run typecheck:web
- npm run lint
- npm run build