### PR TITLE
Prevent long test names from overlapping parameters

### DIFF
--- a/allure-generator/scripts/prepare-playwright-report.mts
+++ b/allure-generator/scripts/prepare-playwright-report.mts
@@ -31,6 +31,7 @@ export const DEFAULT_REPORTS: ReportRequest[] = [
   { fixture: "screen-diff", mode: REPORT_MODES.DIRECTORY },
   { fixture: "playwright-trace", mode: REPORT_MODES.SINGLE_FILE },
   { fixture: "playwright-trace", mode: REPORT_MODES.DIRECTORY },
+  { fixture: "tree-long-name", mode: REPORT_MODES.DIRECTORY },
 ];
 
 const gradleWrapper = path.join(repoRoot, process.platform === "win32" ? "gradlew.bat" : "gradlew");

--- a/allure-generator/src/main/javascript/features/tree/views/renderTreeView.mts
+++ b/allure-generator/src/main/javascript/features/tree/views/renderTreeView.mts
@@ -79,7 +79,7 @@ const createTreeLeaf = (
           text: `#${item.order}`,
         }),
         createElement("div", {
-          className: "node__name",
+          className: "node__name line-ellipsis",
           text: item.name,
         }),
         item.parameters

--- a/allure-generator/tests/e2e/support/fixtures.mts
+++ b/allure-generator/tests/e2e/support/fixtures.mts
@@ -140,4 +140,13 @@ export const fixtures = {
     attachmentName: "Playwright trace",
     stepName: "Record browser trace",
   },
+  treeLongName: {
+    name: "tree-long-name",
+    caseName:
+      "test_screenshot_default_games_section_with_a_descriptive_name_that_remains_long_enough_to_overflow_the_tree_row_even_on_wide_viewports",
+    parameters: [
+      "session[LivePage]",
+      "frontend.pages.screenshot.default.games.section",
+    ],
+  },
 } as const;

--- a/allure-generator/tests/e2e/tree.layout.spec.mts
+++ b/allure-generator/tests/e2e/tree.layout.spec.mts
@@ -1,0 +1,77 @@
+import { expect, test } from "playwright/test";
+import { fixtures, REPORT_MODES } from "./support/fixtures.mts";
+import { openCaseFromTree } from "./support/report.mts";
+
+const fixture = fixtures.treeLongName;
+
+test.describe("Tree layout", () => {
+  test("ellipsizes long test names before parameter text", async ({ page }, testInfo) => {
+    await openCaseFromTree(page, {
+      fixture: fixture.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: fixture.caseName,
+    });
+
+    const title = page.locator(".node__title_active");
+    const name = title.locator(".node__name");
+    const parameters = title.locator(".node__parameters");
+    await expect(name).toHaveText(fixture.caseName);
+    await expect(parameters).toContainText(fixture.parameters[0]);
+    await expect(parameters).toContainText(fixture.parameters[1]);
+
+    const layout = await title.evaluate((element) => {
+      const nameElement = element.querySelector<HTMLElement>(".node__name");
+      const parameterElement = element.querySelector<HTMLElement>(".node__parameters");
+      if (!nameElement || !parameterElement) {
+        throw new Error("Expected the selected tree row to contain a name and parameters");
+      }
+
+      const nameBox = nameElement.getBoundingClientRect();
+      const parameterBox = parameterElement.getBoundingClientRect();
+      const nameTextRange = document.createRange();
+      nameTextRange.selectNodeContents(nameElement);
+      const nameTextBox = nameTextRange.getBoundingClientRect();
+      const nameStyle = getComputedStyle(nameElement);
+      const visibleNameTextRight =
+        nameStyle.overflowX === "visible"
+          ? nameTextBox.right
+          : Math.min(nameTextBox.right, nameBox.right);
+
+      return {
+        titleWidth: element.getBoundingClientRect().width,
+        nameClientWidth: nameElement.clientWidth,
+        nameScrollWidth: nameElement.scrollWidth,
+        nameTextWidth: nameTextBox.width,
+        nameRight: nameBox.right,
+        parametersLeft: parameterBox.left,
+        visibleNameTextRight,
+        visibleOverlapPixels: Math.max(0, visibleNameTextRight - parameterBox.left),
+        nameOverflowX: nameStyle.overflowX,
+        nameTextOverflow: nameStyle.textOverflow,
+        nameWhiteSpace: nameStyle.whiteSpace,
+      };
+    });
+
+    await testInfo.attach("Tree row layout", {
+      body: Buffer.from(JSON.stringify(layout, null, 2)),
+      contentType: "application/json",
+    });
+    await testInfo.attach("Tree row screenshot", {
+      body: await title.screenshot(),
+      contentType: "image/png",
+    });
+
+    expect(
+      layout.nameScrollWidth,
+      "The fixture must force the test name to overflow its layout box",
+    ).toBeGreaterThan(layout.nameClientWidth);
+    expect(
+      layout.visibleNameTextRight,
+      `The test name paints ${layout.visibleOverlapPixels}px into the parameter area`,
+    ).toBeLessThanOrEqual(layout.parametersLeft);
+    await expect(name).toHaveCSS("overflow-x", "hidden");
+    await expect(name).toHaveCSS("text-overflow", "ellipsis");
+    await expect(name).toHaveCSS("white-space", "nowrap");
+  });
+});

--- a/allure-generator/tests/fixtures/raw/tree-long-name/tree-long-name-result.json
+++ b/allure-generator/tests/fixtures/raw/tree-long-name/tree-long-name-result.json
@@ -1,0 +1,58 @@
+{
+  "uuid": "tree-long-name-result",
+  "historyId": "tree-long-name-history",
+  "name": "test_screenshot_default_games_section_with_a_descriptive_name_that_remains_long_enough_to_overflow_the_tree_row_even_on_wide_viewports",
+  "fullName": "frontend.pages.TestScreenshotMainPageDefaultGamesSection.test_screenshot_default_games_section_with_a_descriptive_name_that_remains_long_enough_to_overflow_the_tree_row_even_on_wide_viewports",
+  "status": "passed",
+  "stage": "finished",
+  "description": "Regression fixture for long tree names next to parameter text.",
+  "start": 1710000000000,
+  "stop": 1710000013000,
+  "steps": [],
+  "attachments": [],
+  "parameters": [
+    {
+      "name": "session",
+      "value": "session[LivePage]"
+    },
+    {
+      "name": "page",
+      "value": "frontend.pages.screenshot.default.games.section"
+    }
+  ],
+  "labels": [
+    {
+      "name": "suite",
+      "value": "TestScreenshotMainPageDefaultGamesSection"
+    },
+    {
+      "name": "package",
+      "value": "frontend.pages"
+    },
+    {
+      "name": "testClass",
+      "value": "TestScreenshotMainPageDefaultGamesSection"
+    },
+    {
+      "name": "testMethod",
+      "value": "test_screenshot_default_games_section_with_a_descriptive_name_that_remains_long_enough_to_overflow_the_tree_row_even_on_wide_viewports"
+    },
+    {
+      "name": "framework",
+      "value": "pytest"
+    },
+    {
+      "name": "language",
+      "value": "python"
+    },
+    {
+      "name": "host",
+      "value": "localhost"
+    },
+    {
+      "name": "thread",
+      "value": "main"
+    }
+  ],
+  "links": []
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Long test names in the Suites tree are now shortened with an ellipsis when space is limited, keeping adjacent parameter values readable instead of rendering both strings on top of each other. This fixes parameterized results with lengthy test names across narrow and wide report layouts.

fixes #3422

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2