### PR TITLE
Render duration tooltip ranges correctly

### DIFF
--- a/allure-generator/src/main/javascript/features/test-result/blocks/DurationView.mts
+++ b/allure-generator/src/main/javascript/features/test-result/blocks/DurationView.mts
@@ -26,7 +26,7 @@ const DurationView = (options: TestResultBlockOptions) => {
         time
           ? createElement("span", {
               attrs: {
-                "data-tooltip": `${dateHelper(time.start)} ${timeHelper(time.start)}&nbsp;&ndash;&nbsp;${timeHelper(time.stop)}`,
+                "data-tooltip": `${dateHelper(time.start)} ${timeHelper(time.start)}\u00a0\u2013\u00a0${timeHelper(time.stop)}`,
               },
               children: [
                 `${translate("testResult.duration.name")}: `,

--- a/allure-generator/tests/e2e/testresult.detail.spec.mts
+++ b/allure-generator/tests/e2e/testresult.detail.spec.mts
@@ -44,6 +44,26 @@ for (const mode of reportModes) {
       await expect(execution).toContainText("Open pull requests page");
     });
 
+    test("renders the duration tooltip with an en dash", async ({ page }) => {
+      await openCaseFromTree(page, {
+        fixture: uiDemo.name,
+        mode,
+        tab: "suites",
+        caseName: uiDemo.cases.failedPullRequest,
+      });
+
+      const duration = page.locator(".test-result-overview [data-tooltip]", {
+        hasText: "Duration:",
+      });
+      await duration.hover();
+
+      const tooltip = page.locator(".tooltip");
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toContainText("\u00a0\u2013\u00a0");
+      await expect(tooltip).not.toContainText("&ndash;");
+      await expect(tooltip).not.toContainText("&nbsp;");
+    });
+
     test("links only whole absolute parameter values", async ({ page }) => {
       await openCaseFromTree(page, {
         fixture: detectedLinks.name,


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Duration tooltips now display test start and end times with a proper en dash and spacing. Users no longer see literal `&nbsp;` or `&ndash;` text when hovering over Duration in a test result.

The corrected formatting applies to both single-file and directory reports.

fixes #3442

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2