### PR TITLE
Harden local report previews against path-based security bypasses

### DIFF
--- a/allure-commandline/src/main/java/io/qameta/allure/LocalReportFiles.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/LocalReportFiles.java
@@ -1,0 +1,318 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Resolves and classifies files served by the local report preview server.
+ */
+final class LocalReportFiles {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalReportFiles.class);
+
+    private static final String DATA_DIRECTORY = "data";
+    private static final String ATTACHMENTS_DIRECTORY = "attachments";
+    private static final Set<OpenOption> READ_WITHOUT_FOLLOWING_LINKS = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS))
+    );
+    private static final Set<OpenOption> READ = Collections.singleton(StandardOpenOption.READ);
+
+    private LocalReportFiles() {
+        throw new IllegalStateException("Do not instantiate");
+    }
+
+    static Path resolveReportDirectory(final Path reportDirectory) throws IOException {
+        final Path absoluteReportDirectory = reportDirectory.toAbsolutePath();
+        if (Files.notExists(reportDirectory)) {
+            throw new IOException("Report directory does not exist: " + absoluteReportDirectory);
+        }
+        if (!Files.isDirectory(reportDirectory)) {
+            throw new IOException("Report path is not a directory: " + absoluteReportDirectory);
+        }
+        return reportDirectory.toRealPath();
+    }
+
+    static Optional<Path> resolveRequestedPath(final Path realReportDirectory,
+                                               final String requestedPath) {
+        try {
+            final Path resolvedPath = realReportDirectory.resolve(requestedPath).normalize();
+            return resolveRequestedPath(realReportDirectory, resolvedPath);
+        } catch (InvalidPathException e) {
+            LOGGER.debug("Could not parse requested report path {}", requestedPath, e);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Path> resolveRequestedPath(final Path realReportDirectory,
+                                                       final Path requestedPath) {
+        if (isRejectedPath(realReportDirectory, requestedPath)) {
+            return Optional.empty();
+        }
+        try {
+            final Path realRequestedPath = requestedPath.toRealPath();
+            if (!isWithinDirectory(realReportDirectory, realRequestedPath)) {
+                LOGGER.debug(
+                        "Rejected requested report path {} because it resolves outside {}",
+                        requestedPath,
+                        realReportDirectory
+                );
+                return Optional.empty();
+            }
+            return Optional.of(realRequestedPath);
+        } catch (IOException e) {
+            LOGGER.debug("Could not resolve requested report path {}", requestedPath, e);
+            return Optional.empty();
+        }
+    }
+
+    static boolean isAttachmentPath(final Path realReportDirectory,
+                                    final Path realRequestedPath) {
+        if (!isWithinDirectory(realReportDirectory, realRequestedPath)) {
+            return false;
+        }
+        final Path relativePath = realReportDirectory.relativize(realRequestedPath);
+        return relativePath.getNameCount() >= 3
+                && DATA_DIRECTORY.equalsIgnoreCase(relativePath.getName(0).toString())
+                && ATTACHMENTS_DIRECTORY.equalsIgnoreCase(relativePath.getName(1).toString());
+    }
+
+    static Optional<SeekableByteChannel> openFile(final Path realReportDirectory,
+                                                  final Path realRequestedPath) {
+        return openFile(
+                realReportDirectory,
+                realRequestedPath,
+                LocalReportFiles::doNothing,
+                LocalReportFiles::doNothing
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    static Optional<SeekableByteChannel> openFile(final Path realReportDirectory,
+                                                  final Path realRequestedPath,
+                                                  final FileOpenHook beforeSecureComponentOpen,
+                                                  final FileOpenHook afterSecureFileOpen) {
+        if (isRejectedPath(realReportDirectory, realRequestedPath)) {
+            return Optional.empty();
+        }
+        SeekableByteChannel openedFile = null;
+        try (DirectoryStream<Path> reportDirectoryStream = Files.newDirectoryStream(realReportDirectory)) {
+            if (reportDirectoryStream instanceof SecureDirectoryStream) {
+                openedFile = openSecureFile(
+                        (SecureDirectoryStream<Path>) reportDirectoryStream,
+                        realReportDirectory.relativize(realRequestedPath),
+                        beforeSecureComponentOpen,
+                        afterSecureFileOpen
+                );
+            }
+        } catch (IOException | RuntimeException e) {
+            closeChannel(openedFile);
+            LOGGER.debug("Could not securely open requested report file {}", realRequestedPath, e);
+            return Optional.empty();
+        }
+        if (openedFile != null) {
+            return Optional.of(openedFile);
+        }
+        return openFileWithPathValidation(realReportDirectory, realRequestedPath);
+    }
+
+    static boolean isWithinDirectory(final Path directory,
+                                     final Path requestedPath) {
+        return requestedPath.startsWith(directory);
+    }
+
+    private static boolean isRejectedPath(final Path realReportDirectory,
+                                          final Path requestedPath) {
+        if (!isWithinDirectory(realReportDirectory, requestedPath)) {
+            LOGGER.debug(
+                    "Rejected requested report path {} because it is outside {}",
+                    requestedPath,
+                    realReportDirectory
+            );
+            return true;
+        }
+        final Optional<Path> symbolicLink = findSymbolicLink(realReportDirectory, requestedPath);
+        if (symbolicLink.isPresent()) {
+            LOGGER.debug(
+                    "Rejected requested report path {} because it contains symbolic link {}",
+                    requestedPath,
+                    symbolicLink.get()
+            );
+            return true;
+        }
+        return false;
+    }
+
+    private static Optional<Path> findSymbolicLink(final Path realReportDirectory,
+                                                   final Path requestedPath) {
+        Path currentPath = realReportDirectory;
+        for (Path pathComponent : realReportDirectory.relativize(requestedPath)) {
+            currentPath = currentPath.resolve(pathComponent);
+            if (Files.isSymbolicLink(currentPath)) {
+                return Optional.of(currentPath);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("PMD.CloseResource") // Child streams are transferred between iterations and closed below.
+    static SeekableByteChannel openSecureFile(final SecureDirectoryStream<Path> reportDirectoryStream,
+                                              final Path relativeFile,
+                                              final FileOpenHook beforeOpen,
+                                              final FileOpenHook afterFileOpen)
+            throws IOException {
+        SecureDirectoryStream<Path> currentDirectoryStream = reportDirectoryStream;
+        boolean closeCurrentDirectoryStream = false;
+        SeekableByteChannel openedFile = null;
+        try {
+            for (int index = 0; index < relativeFile.getNameCount() - 1; index++) {
+                beforeOpen.run();
+                final SecureDirectoryStream<Path> nextDirectoryStream = currentDirectoryStream.newDirectoryStream(
+                        relativeFile.getName(index),
+                        LinkOption.NOFOLLOW_LINKS
+                );
+                try {
+                    if (closeCurrentDirectoryStream) {
+                        currentDirectoryStream.close();
+                        closeCurrentDirectoryStream = false;
+                    }
+                } catch (IOException | RuntimeException e) {
+                    closeDirectoryStream(nextDirectoryStream);
+                    throw e;
+                }
+                currentDirectoryStream = nextDirectoryStream;
+                closeCurrentDirectoryStream = true;
+            }
+            beforeOpen.run();
+            openedFile = currentDirectoryStream.newByteChannel(
+                    relativeFile.getFileName(),
+                    READ_WITHOUT_FOLLOWING_LINKS
+            );
+            afterFileOpen.run();
+            if (closeCurrentDirectoryStream) {
+                currentDirectoryStream.close();
+            }
+            return openedFile;
+        } catch (IOException | RuntimeException e) {
+            closeChannel(openedFile);
+            if (closeCurrentDirectoryStream) {
+                closeDirectoryStream(currentDirectoryStream);
+            }
+            throw e;
+        }
+    }
+
+    static Optional<SeekableByteChannel> openFileWithPathValidation(final Path realReportDirectory,
+                                                                    final Path realRequestedPath) {
+        return openFileWithPathValidation(
+                realReportDirectory,
+                realRequestedPath,
+                LocalReportFiles::doNothing,
+                LocalReportFiles::doNothing
+        );
+    }
+
+    static Optional<SeekableByteChannel> openFileWithPathValidation(final Path realReportDirectory,
+                                                                    final Path realRequestedPath,
+                                                                    final FileOpenHook beforeOpen,
+                                                                    final FileOpenHook afterOpen) {
+        if (isRejectedPath(realReportDirectory, realRequestedPath)
+                || !Files.isRegularFile(realRequestedPath, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        SeekableByteChannel channel = null;
+        try {
+            beforeOpen.run();
+            channel = openWithoutFollowingFinalLink(realRequestedPath);
+            afterOpen.run();
+            final Path pathAfterOpen = realRequestedPath.toRealPath();
+            if (!isWithinDirectory(realReportDirectory, pathAfterOpen)
+                    || !realRequestedPath.equals(pathAfterOpen)
+                    || isRejectedPath(realReportDirectory, realRequestedPath)
+                    || !Files.isRegularFile(realRequestedPath, LinkOption.NOFOLLOW_LINKS)) {
+                closeChannel(channel);
+                return Optional.empty();
+            }
+            return Optional.of(channel);
+        } catch (IOException | UnsupportedOperationException e) {
+            closeChannel(channel);
+            LOGGER.debug("Could not open requested report file {}", realRequestedPath, e);
+            return Optional.empty();
+        } catch (RuntimeException e) {
+            closeChannel(channel);
+            throw e;
+        }
+    }
+
+    private static SeekableByteChannel openWithoutFollowingFinalLink(final Path file) throws IOException {
+        try {
+            return Files.newByteChannel(file, READ_WITHOUT_FOLLOWING_LINKS);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.debug(
+                    "File system does not support opening {} with NOFOLLOW_LINKS; using validated fallback",
+                    file,
+                    e
+            );
+            return Files.newByteChannel(file, READ);
+        }
+    }
+
+    private static void closeChannel(final SeekableByteChannel channel) {
+        if (channel == null) {
+            return;
+        }
+        try {
+            channel.close();
+        } catch (IOException e) {
+            LOGGER.debug("Could not close report file channel", e);
+        }
+    }
+
+    private static void closeDirectoryStream(final DirectoryStream<Path> directoryStream) {
+        try {
+            directoryStream.close();
+        } catch (IOException | RuntimeException e) {
+            LOGGER.debug("Could not close report directory stream", e);
+        }
+    }
+
+    private static void doNothing() {
+        // Default hook for production file opening.
+    }
+
+    @FunctionalInterface
+    interface FileOpenHook {
+
+        void run() throws IOException;
+    }
+}

--- a/allure-commandline/src/main/java/io/qameta/allure/LocalReportServer.java
+++ b/allure-commandline/src/main/java/io/qameta/allure/LocalReportServer.java
@@ -17,10 +17,17 @@ package io.qameta.allure;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import io.qameta.allure.detect.ContentTypeDetector;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -34,7 +41,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static io.qameta.allure.DefaultResultsVisitor.probeContentType;
+import static io.qameta.allure.LocalReportFiles.isAttachmentPath;
+import static io.qameta.allure.LocalReportFiles.openFile;
+import static io.qameta.allure.LocalReportFiles.resolveReportDirectory;
+import static io.qameta.allure.LocalReportFiles.resolveRequestedPath;
 
 /**
  * Creates and configures the local-only report preview server used by command-line report viewing.
@@ -48,10 +58,20 @@ import static io.qameta.allure.DefaultResultsVisitor.probeContentType;
  * The policies in this class protect the local preview surface: binding is limited to loopback hosts, request
  * {@code Host} headers are restricted to local names, report responses receive browser hardening headers, and
  * attachment routes are handled conservatively so HTML previews remain usable without giving attachment content
- * script privileges in the report origin.
+ * script privileges in the report origin. The configured report root may itself be a symbolic link, but symbolic
+ * links in request paths are rejected instead of being followed.
+ * <p>
+ * Providers that expose {@link java.nio.file.SecureDirectoryStream} get atomic, component-relative file opening.
+ * Other providers are validated before and after opening the file with {@code NOFOLLOW_LINKS} where supported. The
+ * JDK does not expose an equivalent portable primitive for eliminating concurrent intermediate-directory replacement
+ * on those providers, so the fallback is best-effort and remains appropriate only for this local preview surface.
+ * Portable Java file APIs also cannot distinguish an ordinary file from a hard link to a file outside the report
+ * directory. Do not preview a report tree that is writable by an untrusted local user.
  */
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 final class LocalReportServer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalReportServer.class);
 
     static final String LOCAL_SERVE_MESSAGE = "`allure serve` is intended for local report preview only. "
             + "To host a report, run `allure generate <results-dir> -o <report-dir>` "
@@ -75,7 +95,6 @@ final class LocalReportServer {
     private static final String CSP_FORM_ACTION_NONE = "form-action 'none'; ";
     private static final String LOCALHOST = "localhost";
     private static final String PLAYWRIGHT_TRACE_VIEWER_ORIGIN = "https://trace.playwright.dev";
-    private static final String ATTACHMENTS_REQUEST_PATH = "/data/attachments/";
     private static final Set<String> LOCAL_SERVER_HOSTS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(LOCALHOST, "127.0.0.1", "::1"))
     );
@@ -121,44 +140,72 @@ final class LocalReportServer {
      * @param port the local port to bind
      * @param reportDirectory the generated report directory to preview
      * @return configured local preview server
-     * @throws IOException if the server cannot be created, including when a non-local host is requested
+     * @throws IOException if the report directory is unavailable or the server cannot be created,
+     *                     including when a non-local host is requested
      */
     static HttpServer setUp(final String host, final int port, final Path reportDirectory) throws IOException {
         final String serverHost = Objects.isNull(host) ? LOCALHOST : host;
         if (!isLocalServerHost(serverHost)) {
             throw new IOException(LOCAL_SERVE_MESSAGE);
         }
+        final Path realReportDirectory = resolveReportDirectory(reportDirectory);
         final HttpServer server = HttpServer
                 .create(new InetSocketAddress(serverHost, port), 0);
-        final Path normalizedReportDirectory = reportDirectory.normalize();
 
-        server.createContext(PATH_SEPARATOR, exchange -> {
-            if (!isLocalHostHeader(exchange.getRequestHeaders().getFirst(HEADER_HOST))) {
-                serveForbidden(exchange);
-                return;
-            }
-            final String requestPath = exchange.getRequestURI().getPath();
-            if (!isValidRequestPath(requestPath)) {
-                serveNotFound(exchange);
-                return;
-            }
-            final Path requestedPath = normalizedReportDirectory.resolve(CURRENT_DIRECTORY + requestPath).normalize();
-            if (!isWithinReportDirectory(normalizedReportDirectory, requestedPath)) {
-                serveNotFound(exchange);
-                return;
-            }
-            if (Files.isRegularFile(requestedPath, LinkOption.NOFOLLOW_LINKS)) {
-                serveFile(exchange, requestedPath, isAttachmentRequest(requestPath));
-                return;
-            }
-            if (Files.isDirectory(requestedPath, LinkOption.NOFOLLOW_LINKS)) {
-                serveIndex(exchange, requestedPath.resolve("index.html"));
-                return;
-            }
-            serveNotFound(exchange);
-        });
+        server.createContext(PATH_SEPARATOR, exchange -> serveRequest(exchange, realReportDirectory));
 
         return server;
+    }
+
+    private static void serveRequest(final HttpExchange exchange,
+                                     final Path realReportDirectory)
+            throws IOException {
+        if (!isLocalHostHeader(exchange.getRequestHeaders().getFirst(HEADER_HOST))) {
+            serveForbidden(exchange);
+            return;
+        }
+        final String requestPath = exchange.getRequestURI().getPath();
+        if (!isValidRequestPath(requestPath)) {
+            serveNotFound(exchange);
+            return;
+        }
+        final Optional<Path> realRequestedPath = resolveRequestedPath(
+                realReportDirectory,
+                CURRENT_DIRECTORY + requestPath
+        );
+        if (!realRequestedPath.isPresent()) {
+            serveNotFound(exchange);
+            return;
+        }
+        serveRequestedPath(exchange, realReportDirectory, realRequestedPath.get());
+    }
+
+    private static void serveRequestedPath(final HttpExchange exchange,
+                                           final Path realReportDirectory,
+                                           final Path resolvedRequestedPath)
+            throws IOException {
+        if (Files.isRegularFile(resolvedRequestedPath, LinkOption.NOFOLLOW_LINKS)) {
+            if (!serveFile(
+                    exchange,
+                    realReportDirectory,
+                    resolvedRequestedPath,
+                    isAttachmentPath(realReportDirectory, resolvedRequestedPath)
+            )) {
+                serveNotFound(exchange);
+            }
+            return;
+        }
+        if (Files.isDirectory(resolvedRequestedPath, LinkOption.NOFOLLOW_LINKS)) {
+            final Path indexFile = resolvedRequestedPath.resolve("index.html");
+            serveIndex(
+                    exchange,
+                    realReportDirectory,
+                    indexFile,
+                    isAttachmentPath(realReportDirectory, indexFile)
+            );
+            return;
+        }
+        serveNotFound(exchange);
     }
 
     static boolean isLocalServerHost(final String host) {
@@ -185,11 +232,6 @@ final class LocalReportServer {
         return isLocalServerHost(host);
     }
 
-    static boolean isWithinReportDirectory(final Path normalizedReportDirectory,
-                                           final Path requestedPath) {
-        return requestedPath.startsWith(normalizedReportDirectory);
-    }
-
     private static boolean isValidRequestPath(final String requestPath) {
         return requestPath.indexOf('\\') < 0
                 && Stream.of(requestPath.split(PATH_SEPARATOR))
@@ -197,28 +239,55 @@ final class LocalReportServer {
     }
 
     private static void serveIndex(final HttpExchange exchange,
-                                   final Path indexFile)
+                                   final Path realReportDirectory,
+                                   final Path indexFile,
+                                   final boolean attachmentRequest)
             throws IOException {
-        if (Files.isRegularFile(indexFile, LinkOption.NOFOLLOW_LINKS)) {
-            serveFile(exchange, indexFile, false);
+        if (Files.isRegularFile(indexFile, LinkOption.NOFOLLOW_LINKS)
+                && serveFile(exchange, realReportDirectory, indexFile, attachmentRequest)) {
             return;
         }
         serveNotFound(exchange);
     }
 
-    private static void serveFile(final HttpExchange exchange,
-                                  final Path file,
-                                  final boolean attachmentRequest)
+    private static boolean serveFile(final HttpExchange exchange,
+                                     final Path realReportDirectory,
+                                     final Path file,
+                                     final boolean attachmentRequest)
             throws IOException {
-        final String contentType = Optional.ofNullable(probeContentType(file))
-                .orElse(DefaultResultsVisitor.APPLICATION_OCTET_STREAM);
-        setSecurityHeaders(exchange);
-        setAttachmentHeaders(exchange, contentType, attachmentRequest);
-        exchange.getResponseHeaders().set(HEADER_CONTENT_TYPE, contentType);
-        exchange.sendResponseHeaders(200, Files.size(file));
-        try (OutputStream os = exchange.getResponseBody()) {
-            Files.copy(file, os);
+        final Optional<SeekableByteChannel> openedFile = openFile(realReportDirectory, file);
+        if (!openedFile.isPresent()) {
+            return false;
         }
+        try (SeekableByteChannel channel = openedFile.get()) {
+            final String contentType = probeContentType(file, channel);
+            setSecurityHeaders(exchange);
+            setAttachmentHeaders(exchange, contentType, attachmentRequest);
+            exchange.getResponseHeaders().set(HEADER_CONTENT_TYPE, contentType);
+            exchange.sendResponseHeaders(200, channel.size());
+            try (InputStream input = Channels.newInputStream(channel);
+                    OutputStream output = exchange.getResponseBody()) {
+                IOUtils.copy(input, output);
+            }
+        }
+        return true;
+    }
+
+    static String probeContentType(final Path file,
+                                   final SeekableByteChannel channel)
+            throws IOException {
+        String contentType = ContentTypeDetector.APPLICATION_OCTET_STREAM;
+        try {
+            contentType = ContentTypeDetector.probeContentType(
+                    Channels.newInputStream(channel),
+                    Objects.toString(file.getFileName())
+            );
+        } catch (IOException e) {
+            LOGGER.warn("Couldn't detect the media type of report file {}", file, e);
+        } finally {
+            channel.position(0);
+        }
+        return contentType;
     }
 
     private static void serveNotFound(final HttpExchange exchange) throws IOException {
@@ -267,7 +336,7 @@ final class LocalReportServer {
 
     private static boolean shouldServeAsDownload(final String contentType) {
         final String normalized = normalizeContentType(contentType);
-        return DefaultResultsVisitor.APPLICATION_OCTET_STREAM.equals(normalized)
+        return ContentTypeDetector.APPLICATION_OCTET_STREAM.equals(normalized)
                 || "image/svg+xml".equals(normalized)
                 || "application/pdf".equals(normalized)
                 || "application/xml".equals(normalized)
@@ -285,10 +354,6 @@ final class LocalReportServer {
         return contentType.split(";", 2)[0]
                 .trim()
                 .toLowerCase(Locale.ROOT);
-    }
-
-    private static boolean isAttachmentRequest(final String requestPath) {
-        return requestPath.startsWith(ATTACHMENTS_REQUEST_PATH);
     }
 
     private static String normalizeHost(final String host) {

--- a/allure-commandline/src/test/java/io/qameta/allure/LocalReportFilesTest.java
+++ b/allure-commandline/src/test/java/io/qameta/allure/LocalReportFilesTest.java
@@ -1,0 +1,564 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.opentest4j.TestAbortedException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for resolving and opening files below a local report root.
+ */
+class LocalReportFilesTest {
+
+    /**
+     * Verifies a regular report file resolves to its canonical path.
+     * The test checks redundant path elements do not change the selected file.
+     */
+    @Description
+    @Test
+    void shouldResolveCanonicalFileWithinReportDirectory(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path nestedDirectory = Files.createDirectories(reportDirectory.resolve("nested"));
+        final Path reportFile = Files.writeString(nestedDirectory.resolve("result.json"), "{}");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.resolveRequestedPath(
+                        realReportDirectory,
+                        "./nested/result.json"
+                )
+        ).contains(reportFile.toRealPath());
+    }
+
+    /**
+     * Verifies canonical resolution rejects an intermediate symbolic link.
+     * The test checks a link cannot select a readable file outside the report root.
+     */
+    @Description
+    @Test
+    void shouldRejectCanonicalFileBehindIntermediateSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path outsideDirectory = Files.createDirectories(temp.resolve("outside"));
+        Files.writeString(outsideDirectory.resolve("outside.txt"), "outside");
+        createSymbolicLinkOrSkip(reportDirectory.resolve("link"), outsideDirectory);
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.resolveRequestedPath(
+                        realReportDirectory,
+                        "./link/outside.txt"
+                )
+        ).isEmpty();
+    }
+
+    /**
+     * Verifies canonical files below data/attachments are classified as attachments.
+     * The test checks classification uses the file's location below the real report root.
+     */
+    @Description
+    @Test
+    void shouldClassifyCanonicalAttachmentPath(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path attachments = Files.createDirectories(reportDirectory.resolve("data").resolve("attachments"));
+        final Path attachment = Files.writeString(attachments.resolve("preview.html"), "<p>preview</p>");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.isAttachmentPath(
+                        realReportDirectory,
+                        attachment.toRealPath()
+                )
+        ).isTrue();
+    }
+
+    /**
+     * Verifies attachment classification fails closed for case aliases.
+     * The test checks a mixed-case data/attachments path receives attachment handling.
+     */
+    @Description
+    @Test
+    void shouldClassifyMixedCaseAttachmentPath(@TempDir final Path temp) throws Exception {
+        final Path realReportDirectory = Files.createDirectories(temp.resolve("report")).toRealPath();
+        final Path mixedCaseAttachment = realReportDirectory
+                .resolve("DATA")
+                .resolve("Attachments")
+                .resolve("preview.html");
+
+        assertThat(
+                LocalReportFiles.isAttachmentPath(
+                        realReportDirectory,
+                        mixedCaseAttachment
+                )
+        ).isTrue();
+    }
+
+    /**
+     * Verifies report application files are not classified as attachments.
+     * The test checks only files below data/attachments receive attachment handling.
+     */
+    @Description
+    @Test
+    void shouldNotClassifyCanonicalReportPathAsAttachment(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("index.html"), "<p>report</p>");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.isAttachmentPath(
+                        realReportDirectory,
+                        reportFile.toRealPath()
+                )
+        ).isFalse();
+    }
+
+    /**
+     * Verifies the final file-opening step does not follow symbolic links.
+     * The test checks a symbolic-link file cannot be opened after path validation.
+     */
+    @Description
+    @Test
+    void shouldRejectOpeningSymbolicLinkFile(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path fileLink = realReportDirectory.resolve("file-link.txt");
+        createSymbolicLinkOrSkip(fileLink, outsideFile.toRealPath());
+
+        assertThat(LocalReportFiles.openFile(realReportDirectory, fileLink)).isEmpty();
+        assertThat(LocalReportFiles.openFileWithPathValidation(realReportDirectory, fileLink)).isEmpty();
+    }
+
+    /**
+     * Verifies the validated fallback opens regular report files.
+     * The test checks the returned channel contains the exact file bytes.
+     */
+    @Description
+    @Test
+    void shouldOpenRegularFileWithPathValidationFallback(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        try (SeekableByteChannel channel = LocalReportFiles
+                .openFileWithPathValidation(realReportDirectory, reportFile.toRealPath())
+                .orElseThrow(AssertionError::new)) {
+            assertThat(readChannel(channel)).isEqualTo("inside");
+        }
+    }
+
+    /**
+     * Verifies the validated fallback rejects files outside the report root.
+     * The test checks an otherwise readable canonical file is not opened.
+     */
+    @Description
+    @Test
+    void shouldRejectOutsideFileWithPathValidationFallback(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.openFileWithPathValidation(
+                        realReportDirectory,
+                        outsideFile.toRealPath()
+                )
+        ).isEmpty();
+    }
+
+    /**
+     * Verifies the validated fallback serves only regular existing files.
+     * The test checks missing paths and directories are both rejected.
+     */
+    @Description
+    @Test
+    void shouldRejectMissingPathAndDirectoryWithPathValidationFallback(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path nestedDirectory = Files.createDirectories(reportDirectory.resolve("nested"));
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+
+        assertThat(
+                LocalReportFiles.openFileWithPathValidation(
+                        realReportDirectory,
+                        realReportDirectory.resolve("missing.txt")
+                )
+        ).isEmpty();
+        assertThat(
+                LocalReportFiles.openFileWithPathValidation(
+                        realReportDirectory,
+                        nestedDirectory.toRealPath()
+                )
+        ).isEmpty();
+    }
+
+    /**
+     * Verifies serving remains bound to the file handle opened after validation.
+     * The test checks replacing its directory entry with a symlink cannot redirect the opened content.
+     */
+    @Description
+    @Test
+    void shouldKeepOpenedFileBoundWhenPathIsReplaced(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+
+        try (SeekableByteChannel channel = LocalReportFiles.openFile(realReportDirectory, realReportFile)
+                .orElseThrow(AssertionError::new)) {
+            replaceWithSymbolicLinkOrSkip(realReportFile, outsideFile);
+            try (InputStream input = Channels.newInputStream(channel)) {
+                assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("inside");
+            }
+        }
+    }
+
+    /**
+     * Verifies a final symlink introduced after pre-validation is rejected.
+     * The test checks the fallback reaches its no-follow open rather than relying on the initial guard.
+     */
+    @Description
+    @Test
+    void shouldRejectFinalSymlinkCreatedBeforeFallbackOpen(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside").toRealPath();
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+        verifySymbolicLinkSupport(realReportDirectory.resolve("probe-link"), outsideFile);
+
+        assertThat(
+                LocalReportFiles.openFileWithPathValidation(
+                        realReportDirectory,
+                        realReportFile,
+                        () -> replaceWithSymbolicLink(realReportFile, outsideFile),
+                        () -> {
+                        }
+                )
+        ).isEmpty();
+        assertThat(Files.isSymbolicLink(realReportFile)).isTrue();
+    }
+
+    /**
+     * Verifies a path replacement after the fallback open fails post-open validation.
+     * The test checks the opened channel is rejected before it can be returned for serving.
+     */
+    @Description
+    @Test
+    void shouldRejectFinalSymlinkCreatedAfterFallbackOpen(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside").toRealPath();
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+        verifySymbolicLinkSupport(realReportDirectory.resolve("probe-link"), outsideFile);
+
+        assertThat(
+                LocalReportFiles.openFileWithPathValidation(
+                        realReportDirectory,
+                        realReportFile,
+                        () -> {
+                        },
+                        () -> replaceWithSymbolicLink(realReportFile, outsideFile)
+                )
+        ).isEmpty();
+        assertThat(Files.isSymbolicLink(realReportFile)).isTrue();
+    }
+
+    /**
+     * Verifies secure opening rejects a final symlink introduced after the initial path check.
+     * The test checks the component-relative byte-channel open uses no-follow semantics.
+     */
+    @Description
+    @Test
+    void shouldRejectFinalSymlinkCreatedBeforeSecureOpen(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside").toRealPath();
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+        assumeSecureDirectoryStream(realReportDirectory);
+        verifySymbolicLinkSupport(realReportDirectory.resolve("probe-link"), outsideFile);
+        final AtomicBoolean beforeOpenInvoked = new AtomicBoolean();
+
+        assertThat(
+                LocalReportFiles.openFile(
+                        realReportDirectory,
+                        realReportFile,
+                        () -> {
+                            beforeOpenInvoked.set(true);
+                            replaceWithSymbolicLink(realReportFile, outsideFile);
+                        },
+                        this::doNothing
+                )
+        ).isEmpty();
+        assertThat(beforeOpenInvoked).isTrue();
+        assertThat(Files.isSymbolicLink(realReportFile)).isTrue();
+    }
+
+    /**
+     * Verifies secure opening rejects an intermediate symlink introduced after the initial path check.
+     * The test checks component-relative directory traversal does not follow the replacement.
+     */
+    @Description
+    @Test
+    void shouldRejectIntermediateSymlinkCreatedBeforeSecureDirectoryOpen(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path nestedDirectory = Files.createDirectories(reportDirectory.resolve("nested"));
+        final Path reportFile = Files.writeString(nestedDirectory.resolve("result.txt"), "inside");
+        final Path outsideDirectory = Files.createDirectories(temp.resolve("outside")).toRealPath();
+        Files.writeString(outsideDirectory.resolve("result.txt"), "outside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realNestedDirectory = nestedDirectory.toRealPath();
+        final Path realReportFile = reportFile.toRealPath();
+        assumeSecureDirectoryStream(realReportDirectory);
+        verifySymbolicLinkSupport(realReportDirectory.resolve("probe-link"), outsideDirectory);
+        final AtomicBoolean beforeDirectoryOpenInvoked = new AtomicBoolean();
+
+        assertThat(
+                LocalReportFiles.openFile(
+                        realReportDirectory,
+                        realReportFile,
+                        () -> {
+                            if (beforeDirectoryOpenInvoked.compareAndSet(false, true)) {
+                                replaceDirectoryWithSymbolicLink(
+                                        realNestedDirectory,
+                                        realReportFile,
+                                        outsideDirectory
+                                );
+                            }
+                        },
+                        this::doNothing
+                )
+        ).isEmpty();
+        assertThat(beforeDirectoryOpenInvoked).isTrue();
+        assertThat(Files.isSymbolicLink(realNestedDirectory)).isTrue();
+    }
+
+    /**
+     * Verifies secure opening stays bound when the path changes after the byte channel opens.
+     * The test checks the returned channel still contains the original report bytes.
+     */
+    @Description
+    @Test
+    void shouldKeepSecureFileBoundWhenPathIsReplacedAfterOpen(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside").toRealPath();
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+        assumeSecureDirectoryStream(realReportDirectory);
+        verifySymbolicLinkSupport(realReportDirectory.resolve("probe-link"), outsideFile);
+        final AtomicBoolean afterOpenInvoked = new AtomicBoolean();
+
+        try (SeekableByteChannel channel = LocalReportFiles.openFile(
+                realReportDirectory,
+                realReportFile,
+                this::doNothing,
+                () -> {
+                    afterOpenInvoked.set(true);
+                    replaceWithSymbolicLink(realReportFile, outsideFile);
+                }
+        ).orElseThrow(AssertionError::new)) {
+            assertThat(afterOpenInvoked).isTrue();
+            assertThat(Files.isSymbolicLink(realReportFile)).isTrue();
+            assertThat(readChannel(channel)).isEqualTo("inside");
+        }
+    }
+
+    /**
+     * Verifies secure file opening passes no-follow to the byte-channel operation.
+     * The test checks the exact open options used for the final path component.
+     */
+    @Description
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRequestNoFollowWhenOpeningSecureFile() throws Exception {
+        final SecureDirectoryStream<Path> directoryStream = mock(SecureDirectoryStream.class);
+        final SeekableByteChannel expectedChannel = mock(SeekableByteChannel.class);
+        final Path relativeFile = Path.of("result.txt");
+        when(directoryStream.newByteChannel(eq(relativeFile), anySet())).thenReturn(expectedChannel);
+
+        final SeekableByteChannel openedChannel = LocalReportFiles.openSecureFile(
+                directoryStream,
+                relativeFile,
+                this::doNothing,
+                this::doNothing
+        );
+        final ArgumentCaptor<Set<? extends OpenOption>> options = ArgumentCaptor.forClass(Set.class);
+        verify(directoryStream).newByteChannel(eq(relativeFile), options.capture());
+        final Set<OpenOption> capturedOptions = new HashSet<>(options.getValue());
+
+        assertThat(openedChannel).isSameAs(expectedChannel);
+        assertThat(capturedOptions)
+                .contains(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    /**
+     * Verifies secure directory traversal passes no-follow to each intermediate open.
+     * The test checks the child stream is opened without following a replacement link.
+     */
+    @Description
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRequestNoFollowWhenOpeningSecureDirectory() throws Exception {
+        final SecureDirectoryStream<Path> reportDirectoryStream = mock(SecureDirectoryStream.class);
+        final SecureDirectoryStream<Path> nestedDirectoryStream = mock(SecureDirectoryStream.class);
+        final SecureDirectoryStream<Path> deeperDirectoryStream = mock(SecureDirectoryStream.class);
+        final SeekableByteChannel expectedChannel = mock(SeekableByteChannel.class);
+        final Path nestedDirectory = Path.of("nested");
+        final Path deeperDirectory = Path.of("deeper");
+        final Path relativeFile = nestedDirectory.resolve(deeperDirectory).resolve("result.txt");
+        when(
+                reportDirectoryStream.newDirectoryStream(
+                        eq(nestedDirectory),
+                        eq(LinkOption.NOFOLLOW_LINKS)
+                )
+        ).thenReturn(nestedDirectoryStream);
+        when(
+                nestedDirectoryStream.newDirectoryStream(
+                        eq(deeperDirectory),
+                        eq(LinkOption.NOFOLLOW_LINKS)
+                )
+        ).thenReturn(deeperDirectoryStream);
+        when(
+                deeperDirectoryStream.newByteChannel(
+                        eq(relativeFile.getFileName()),
+                        anySet()
+                )
+        ).thenReturn(expectedChannel);
+
+        final SeekableByteChannel openedChannel = LocalReportFiles.openSecureFile(
+                reportDirectoryStream,
+                relativeFile,
+                this::doNothing,
+                this::doNothing
+        );
+
+        assertThat(openedChannel).isSameAs(expectedChannel);
+        verify(reportDirectoryStream).newDirectoryStream(
+                nestedDirectory,
+                LinkOption.NOFOLLOW_LINKS
+        );
+        verify(nestedDirectoryStream).newDirectoryStream(
+                deeperDirectory,
+                LinkOption.NOFOLLOW_LINKS
+        );
+        verify(reportDirectoryStream, never()).close();
+        verify(nestedDirectoryStream).close();
+        verify(deeperDirectoryStream).close();
+    }
+
+    /**
+     * Verifies the validated fallback stays bound to the opened file handle.
+     * The test checks replacing the directory entry cannot redirect the returned channel.
+     */
+    @Description
+    @Test
+    void shouldKeepFallbackFileBoundWhenPathIsReplaced(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path reportFile = Files.writeString(reportDirectory.resolve("result.txt"), "inside");
+        final Path outsideFile = Files.writeString(temp.resolve("outside.txt"), "outside");
+        final Path realReportDirectory = LocalReportFiles.resolveReportDirectory(reportDirectory);
+        final Path realReportFile = reportFile.toRealPath();
+
+        try (SeekableByteChannel channel = LocalReportFiles
+                .openFileWithPathValidation(realReportDirectory, realReportFile)
+                .orElseThrow(AssertionError::new)) {
+            replaceWithSymbolicLinkOrSkip(realReportFile, outsideFile);
+            assertThat(readChannel(channel)).isEqualTo("inside");
+        }
+    }
+
+    private String readChannel(final SeekableByteChannel channel) throws IOException {
+        try (InputStream input = Channels.newInputStream(channel)) {
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private void createSymbolicLinkOrSkip(final Path link, final Path target) throws IOException {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException e) {
+            throw new TestAbortedException("Symbolic links are not supported in this environment", e);
+        }
+    }
+
+    private void replaceWithSymbolicLinkOrSkip(final Path file, final Path target) throws IOException {
+        try {
+            replaceWithSymbolicLink(file, target);
+        } catch (UnsupportedOperationException | IOException e) {
+            throw new TestAbortedException("Open files cannot be replaced in this environment", e);
+        }
+    }
+
+    private void replaceWithSymbolicLink(final Path file, final Path target) throws IOException {
+        Files.delete(file);
+        Files.createSymbolicLink(file, target);
+    }
+
+    private void replaceDirectoryWithSymbolicLink(final Path directory,
+                                                  final Path containedFile,
+                                                  final Path target)
+            throws IOException {
+        Files.delete(containedFile);
+        Files.delete(directory);
+        Files.createSymbolicLink(directory, target);
+    }
+
+    private void verifySymbolicLinkSupport(final Path link, final Path target) throws IOException {
+        createSymbolicLinkOrSkip(link, target);
+        Files.delete(link);
+    }
+
+    private void assumeSecureDirectoryStream(final Path directory) throws IOException {
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory)) {
+            assumeTrue(
+                    directoryStream instanceof SecureDirectoryStream,
+                    "SecureDirectoryStream is not supported by the test file system"
+            );
+        }
+    }
+
+    private void doNothing() {
+    }
+}

--- a/allure-commandline/src/test/java/io/qameta/allure/LocalReportServerTest.java
+++ b/allure-commandline/src/test/java/io/qameta/allure/LocalReportServerTest.java
@@ -25,13 +25,20 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the local-only Allure report preview server.
@@ -65,6 +72,44 @@ class LocalReportServerTest {
     }
 
     /**
+     * Verifies the configured report root may itself be a symbolic link.
+     * The test checks files are served from the canonical target directory.
+     */
+    @Description
+    @Test
+    void shouldServeReportWhenReportDirectoryIsSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        Files.writeString(reportDirectory.resolve("app.js"), "console.log('report');");
+        final Path attachments = Files.createDirectories(reportDirectory.resolve("data").resolve("attachments"));
+        Files.writeString(attachments.resolve("preview.html"), "<p>attachment preview</p>");
+        final Path reportLink = temp.resolve("report-link");
+        createSymbolicLinkOrSkip(reportLink, reportDirectory);
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportLink);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection fileRequest = openConnection(port, "/app.js");
+            assertThat(fileRequest.getResponseCode()).isEqualTo(200);
+            assertThat(readResponse(fileRequest)).isEqualTo("console.log('report');");
+
+            final HttpURLConnection attachmentRequest = openConnection(
+                    port,
+                    "/data/attachments/preview.html"
+            );
+            assertThat(attachmentRequest.getResponseCode()).isEqualTo(200);
+            assertThat(attachmentRequest.getHeaderField("Content-Security-Policy"))
+                    .contains("sandbox")
+                    .contains("default-src 'none'");
+            assertThat(readResponse(attachmentRequest)).isEqualTo("<p>attachment preview</p>");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
      * Verifies the report server refuses to bind to a remote-facing host.
      * The test checks allure serve stays a local preview command by default.
      */
@@ -76,6 +121,34 @@ class LocalReportServerTest {
         assertThatThrownBy(() -> LocalReportServer.setUp("0.0.0.0", 0, reportDirectory))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("local report preview only");
+    }
+
+    /**
+     * Verifies server setup rejects a report directory that does not exist.
+     * The test checks the error identifies the unavailable directory.
+     */
+    @Description
+    @Test
+    void shouldRejectMissingReportDirectory(@TempDir final Path temp) {
+        final Path missingReportDirectory = temp.resolve("missing-report");
+
+        assertThatThrownBy(() -> LocalReportServer.setUp("127.0.0.1", 0, missingReportDirectory))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Report directory does not exist: " + missingReportDirectory.toAbsolutePath());
+    }
+
+    /**
+     * Verifies server setup rejects an existing path that is not a directory.
+     * The test checks the error identifies the invalid report path.
+     */
+    @Description
+    @Test
+    void shouldRejectReportPathThatIsNotDirectory(@TempDir final Path temp) throws Exception {
+        final Path reportFile = Files.writeString(temp.resolve("report.html"), "report");
+
+        assertThatThrownBy(() -> LocalReportServer.setUp("127.0.0.1", 0, reportFile))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Report path is not a directory: " + reportFile.toAbsolutePath());
     }
 
     /**
@@ -174,6 +247,131 @@ class LocalReportServerTest {
             assertThat(attachmentRequest.getHeaderField("X-Frame-Options")).isEqualTo("SAMEORIGIN");
             assertThat(attachmentRequest.getHeaderField("X-Content-Type-Options")).isEqualTo("nosniff");
             assertThat(readResponse(attachmentRequest)).isEqualTo("<script>alert(1)</script>");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies attachment security policy is based on the resolved file location.
+     * The test checks a doubled slash cannot make an HTML attachment receive the report policy.
+     */
+    @Description
+    @Test
+    void shouldSandboxHtmlAttachmentRequestedWithDoubledSlash(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path attachments = Files.createDirectories(reportDirectory.resolve("data").resolve("attachments"));
+        Files.writeString(attachments.resolve("preview.html"), "<p>attachment preview</p>");
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final String response = readRawHttpResponse(
+                    port,
+                    "127.0.0.1:" + port,
+                    "/data//attachments/preview.html"
+            ).toLowerCase(Locale.ROOT);
+            assertThat(response)
+                    .contains("http/1.1 200 ok")
+                    .contains("content-security-policy: sandbox; default-src 'none';")
+                    .contains("x-frame-options: sameorigin");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies attachment security policy is based on the decoded and resolved file location.
+     * The test checks an encoded slash cannot make an HTML attachment receive the report policy.
+     */
+    @Description
+    @Test
+    void shouldSandboxHtmlAttachmentRequestedWithEncodedSlash(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path attachments = Files.createDirectories(reportDirectory.resolve("data").resolve("attachments"));
+        Files.writeString(attachments.resolve("preview.html"), "<p>attachment preview</p>");
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final String response = readRawHttpResponse(
+                    port,
+                    "127.0.0.1:" + port,
+                    "/data/%2fattachments/preview.html"
+            ).toLowerCase(Locale.ROOT);
+            assertThat(response)
+                    .contains("http/1.1 200 ok")
+                    .contains("content-security-policy: sandbox; default-src 'none';")
+                    .contains("x-frame-options: sameorigin");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies path aliases do not over-classify report application files as attachments.
+     * The test checks a doubled-slash report URL retains the report CSP.
+     */
+    @Description
+    @Test
+    void shouldServeReportFileRequestedWithDoubledSlashUsingReportPolicy(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path nestedDirectory = Files.createDirectories(reportDirectory.resolve("nested"));
+        Files.writeString(nestedDirectory.resolve("index.html"), "<p>report</p>");
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final String response = readRawHttpResponse(
+                    port,
+                    "127.0.0.1:" + port,
+                    "/nested//index.html"
+            ).toLowerCase(Locale.ROOT);
+            assertThat(response)
+                    .contains("http/1.1 200 ok")
+                    .contains("content-security-policy: default-src 'self'")
+                    .doesNotContain("content-security-policy: sandbox");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies directory indexes below the attachment directory retain attachment security policy.
+     * The test checks an attachment index receives the restrictive sandbox CSP.
+     */
+    @Description
+    @Test
+    void shouldSandboxHtmlAttachmentDirectoryIndex(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path attachmentDirectory = Files.createDirectories(
+                reportDirectory.resolve("data").resolve("attachments").resolve("nested")
+        );
+        Files.writeString(attachmentDirectory.resolve("index.html"), "<p>attachment index</p>");
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection attachmentRequest = openConnection(port, "/data/attachments/nested/");
+            assertThat(attachmentRequest.getResponseCode()).isEqualTo(200);
+            assertThat(attachmentRequest.getHeaderField("Content-Security-Policy"))
+                    .contains("sandbox")
+                    .contains("default-src 'none'")
+                    .contains("frame-ancestors 'self'");
+            assertThat(attachmentRequest.getHeaderField("X-Frame-Options")).isEqualTo("SAMEORIGIN");
+            assertThat(readResponse(attachmentRequest)).isEqualTo("<p>attachment index</p>");
         } finally {
             server.stop(0);
         }
@@ -317,6 +515,77 @@ class LocalReportServerTest {
     }
 
     /**
+     * Verifies the primary report URL serves the report-root index.
+     * The test checks a request for the root path returns the generated report entry point.
+     */
+    @Description
+    @Test
+    void shouldServeReportRootIndex(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        Files.writeString(reportDirectory.resolve("index.html"), "report");
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection rootRequest = openConnection(port, "/");
+            assertThat(rootRequest.getResponseCode()).isEqualTo(200);
+            assertThat(readResponse(rootRequest)).isEqualTo("report");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies a report root reached through a symlinked parent is canonicalized.
+     * The test checks files remain servable from the real report directory.
+     */
+    @Description
+    @Test
+    void shouldServeReportWhenParentDirectoryIsSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path actualParent = Files.createDirectories(temp.resolve("actual-parent"));
+        final Path reportDirectory = Files.createDirectories(actualParent.resolve("report"));
+        Files.writeString(reportDirectory.resolve("index.html"), "report");
+        final Path parentLink = temp.resolve("parent-link");
+        createSymbolicLinkOrSkip(parentLink, actualParent);
+
+        final HttpServer server = LocalReportServer.setUp(
+                "127.0.0.1",
+                0,
+                parentLink.resolve("report")
+        );
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection rootRequest = openConnection(port, "/");
+            assertThat(rootRequest.getResponseCode()).isEqualTo(200);
+            assertThat(readResponse(rootRequest)).isEqualTo("report");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies content-type read failures use the safe generic type.
+     * The test checks the channel is rewound before serving continues.
+     */
+    @Description
+    @Test
+    void shouldUseOctetStreamWhenContentTypeProbeFails() throws Exception {
+        final SeekableByteChannel channel = mock(SeekableByteChannel.class);
+        when(channel.read(any(ByteBuffer.class))).thenThrow(new IOException("probe failed"));
+        when(channel.position(0)).thenReturn(channel);
+
+        assertThat(LocalReportServer.probeContentType(Path.of("attachment"), channel))
+                .isEqualTo("application/octet-stream");
+        verify(channel).position(0);
+    }
+
+    /**
      * Verifies encoded traversal attempts are rejected by the report server.
      * The test checks a normalized outside path returns a 404 response.
      */
@@ -343,16 +612,44 @@ class LocalReportServerTest {
     }
 
     /**
-     * Verifies explicit path-boundary checks reject paths outside the normalized report directory.
-     * The test checks a normalized parent traversal target is not considered inside the report directory.
+     * Verifies platform-invalid filesystem paths are handled as missing report files.
+     * The test checks an encoded null character receives a complete 404 response.
      */
     @Description
     @Test
-    void shouldDetectResolvedPathOutsideNormalizedReportDirectory(@TempDir final Path temp) throws Exception {
-        final Path normalizedReportDirectory = Files.createDirectories(temp.resolve("report")).normalize();
-        final Path requestedPath = normalizedReportDirectory.resolve("../outside.txt").normalize();
+    void shouldReturnNotFoundForPlatformInvalidRequestPath(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
 
-        assertThat(LocalReportServer.isWithinReportDirectory(normalizedReportDirectory, requestedPath))
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final String response = readRawHttpResponse(
+                    port,
+                    "127.0.0.1:" + port,
+                    "/invalid%00path"
+            );
+            assertThat(response)
+                    .contains("404 Not Found")
+                    .endsWith("404 Not Found");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies explicit path-boundary checks reject paths outside the report directory.
+     * The test checks a parent traversal target is not considered inside the report directory.
+     */
+    @Description
+    @Test
+    void shouldDetectResolvedPathOutsideReportDirectory(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report")).normalize();
+        final Path requestedPath = reportDirectory.resolve("../outside.txt").normalize();
+
+        assertThat(LocalReportFiles.isWithinDirectory(reportDirectory, requestedPath))
                 .isFalse();
     }
 
@@ -374,6 +671,85 @@ class LocalReportServerTest {
             final HttpURLConnection missingFileRequest = openConnection(port, "/missing.js");
             assertThat(missingFileRequest.getResponseCode()).isEqualTo(404);
             assertThat(readResponse(missingFileRequest)).isEqualTo("404 Not Found");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies files reached through an intermediate symbolic link cannot escape the report directory.
+     * The test checks a regular file outside the report root returns a not-found response.
+     */
+    @Description
+    @Test
+    void shouldRejectFileBehindIntermediateSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path outsideDirectory = Files.createDirectories(temp.resolve("outside"));
+        Files.writeString(outsideDirectory.resolve("outside.txt"), "outside");
+        createSymbolicLinkOrSkip(reportDirectory.resolve("link"), outsideDirectory);
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection outsideFileRequest = openConnection(port, "/link/outside.txt");
+            assertThat(outsideFileRequest.getResponseCode()).isEqualTo(404);
+            assertThat(readResponse(outsideFileRequest)).isEqualTo("404 Not Found");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies request paths do not follow intermediate symbolic links within the report directory.
+     * The test checks the same no-symlink policy applies even when the target stays inside the report root.
+     */
+    @Description
+    @Test
+    void shouldRejectFileBehindInternalIntermediateSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path nestedDirectory = Files.createDirectories(reportDirectory.resolve("nested"));
+        Files.writeString(nestedDirectory.resolve("nested.txt"), "nested");
+        createSymbolicLinkOrSkip(reportDirectory.resolve("link"), nestedDirectory);
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection linkedFileRequest = openConnection(port, "/link/nested.txt");
+            assertThat(linkedFileRequest.getResponseCode()).isEqualTo(404);
+            assertThat(readResponse(linkedFileRequest)).isEqualTo("404 Not Found");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Verifies directory indexes reached through an intermediate symbolic link cannot escape the report directory.
+     * The test checks a nested index outside the report root returns a not-found response.
+     */
+    @Description
+    @Test
+    void shouldRejectIndexBehindIntermediateSymbolicLink(@TempDir final Path temp) throws Exception {
+        final Path reportDirectory = Files.createDirectories(temp.resolve("report"));
+        final Path outsideDirectory = Files.createDirectories(temp.resolve("outside"));
+        final Path nestedDirectory = Files.createDirectories(outsideDirectory.resolve("nested"));
+        Files.writeString(nestedDirectory.resolve("index.html"), "outside");
+        createSymbolicLinkOrSkip(reportDirectory.resolve("link"), outsideDirectory);
+
+        final HttpServer server = LocalReportServer.setUp("127.0.0.1", 0, reportDirectory);
+        server.start();
+
+        try {
+            final int port = server.getAddress().getPort();
+
+            final HttpURLConnection outsideIndexRequest = openConnection(port, "/link/nested/");
+            assertThat(outsideIndexRequest.getResponseCode()).isEqualTo(404);
+            assertThat(readResponse(outsideIndexRequest)).isEqualTo("404 Not Found");
         } finally {
             server.stop(0);
         }

--- a/allure-generator/src/main/java/io/qameta/allure/DefaultResultsVisitor.java
+++ b/allure-generator/src/main/java/io/qameta/allure/DefaultResultsVisitor.java
@@ -19,7 +19,7 @@ import io.qameta.allure.context.RandomUidContext;
 import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.core.ResultsVisitor;
-import io.qameta.allure.detect.MagicBytesContentTypeDetector;
+import io.qameta.allure.detect.ContentTypeDetector;
 import io.qameta.allure.detect.WellKnownFileExtensionsUtils;
 import io.qameta.allure.entity.Attachment;
 import io.qameta.allure.entity.Parameter;
@@ -55,10 +55,7 @@ public class DefaultResultsVisitor implements ResultsVisitor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultResultsVisitor.class);
 
-    public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
-
-    // so far maximum offset is 512 for supported files
-    private static final int MAGIC_HEADER_LENGTH = 1024;
+    public static final String APPLICATION_OCTET_STREAM = ContentTypeDetector.APPLICATION_OCTET_STREAM;
 
     private static final String UNKNOWN_PARAMETER_VALUE = "#___unknown_value___#";
 
@@ -193,20 +190,8 @@ public class DefaultResultsVisitor implements ResultsVisitor {
     }
 
     private static String probeContentType(final InputStream is, final String name) throws IOException {
-        // first try to detect using name if provided
-        final String lookup = WellKnownFileExtensionsUtils.lookup(name);
-        if (Objects.nonNull(lookup)) {
-            return lookup;
-        }
-
-        // try to read file header bytes and detect using magic bytes detector
         try (InputStream stream = new BufferedInputStream(is)) {
-            final byte[] buffer = new byte[MAGIC_HEADER_LENGTH];
-            final int bytesRead = stream.read(buffer);
-            if (bytesRead <= 0) {
-                return APPLICATION_OCTET_STREAM;
-            }
-            return MagicBytesContentTypeDetector.detectContentType(buffer);
+            return ContentTypeDetector.probeContentType(stream, name);
         }
     }
 

--- a/allure-generator/src/main/java/io/qameta/allure/detect/ContentTypeDetector.java
+++ b/allure-generator/src/main/java/io/qameta/allure/detect/ContentTypeDetector.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.detect;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Detects content types from well-known file extensions and file headers.
+ */
+public final class ContentTypeDetector {
+
+    public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+
+    // So far the maximum offset is 512 for supported files.
+    private static final int MAGIC_HEADER_LENGTH = 1024;
+
+    private ContentTypeDetector() {
+        throw new IllegalStateException("Do not instantiate");
+    }
+
+    public static String probeContentType(final InputStream stream,
+                                          final String fileName)
+            throws IOException {
+        final String contentTypeByName = WellKnownFileExtensionsUtils.lookup(fileName);
+        if (Objects.nonNull(contentTypeByName)) {
+            return contentTypeByName;
+        }
+
+        final byte[] buffer = new byte[MAGIC_HEADER_LENGTH];
+        final int bytesRead = IOUtils.read(stream, buffer);
+        if (bytesRead <= 0) {
+            return APPLICATION_OCTET_STREAM;
+        }
+        return Optional.ofNullable(
+                MagicBytesContentTypeDetector.detectContentType(Arrays.copyOf(buffer, bytesRead))
+        ).orElse(APPLICATION_OCTET_STREAM);
+    }
+}

--- a/allure-generator/src/test/java/io/qameta/allure/detect/ContentTypeDetectorTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/detect/ContentTypeDetectorTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.detect;
+
+import io.qameta.allure.Description;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for combined extension and magic-byte content-type detection.
+ */
+class ContentTypeDetectorTest {
+
+    /**
+     * Verifies a well-known extension is resolved without reading file content.
+     * The test checks an unavailable stream does not affect extension detection.
+     */
+    @Description
+    @Test
+    void shouldPreferContentTypeFromFileName() throws Exception {
+        final InputStream unreadable = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("must not read");
+            }
+        };
+
+        assertThat(ContentTypeDetector.probeContentType(unreadable, "preview.html"))
+                .isEqualTo("text/html");
+    }
+
+    /**
+     * Verifies unknown extensions fall back to magic-byte detection.
+     * The test checks a PNG header is recognized from file content.
+     */
+    @Description
+    @Test
+    void shouldDetectContentTypeFromMagicBytes() throws Exception {
+        final byte[] pngHeader = new byte[]{
+                (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        };
+
+        assertThat(
+                ContentTypeDetector.probeContentType(
+                        new ByteArrayInputStream(pngHeader),
+                        "attachment"
+                )
+        ).isEqualTo("image/png");
+    }
+
+    /**
+     * Verifies magic-byte probing fills the header across short stream reads.
+     * The test checks a tar signature beyond the first chunk remains detectable.
+     */
+    @Description
+    @Test
+    void shouldDetectContentTypeAcrossShortReads() throws Exception {
+        final byte[] tarContent = new byte[512];
+        final byte[] tarSignature = new byte[]{'u', 's', 't', 'a', 'r', ' ', ' ', 0};
+        System.arraycopy(tarSignature, 0, tarContent, 257, tarSignature.length);
+        final InputStream shortReadStream = new ByteArrayInputStream(tarContent) {
+            @Override
+            public synchronized int read(final byte[] buffer,
+                                         final int offset,
+                                         final int length) {
+                return super.read(buffer, offset, Math.min(length, 64));
+            }
+        };
+
+        assertThat(ContentTypeDetector.probeContentType(shortReadStream, "attachment"))
+                .isEqualTo("application/x-gtar");
+    }
+
+    /**
+     * Verifies empty unknown content uses the generic binary type.
+     * The test checks callers receive a non-null safe default.
+     */
+    @Description
+    @Test
+    void shouldUseOctetStreamForEmptyUnknownContent() throws Exception {
+        assertThat(
+                ContentTypeDetector.probeContentType(
+                        new ByteArrayInputStream(new byte[0]),
+                        "attachment"
+                )
+        ).isEqualTo(ContentTypeDetector.APPLICATION_OCTET_STREAM);
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Local reports opened with `allure open` or `allure serve` now resolve request paths before serving or classifying files. This prevents intermediate symlinks from exposing files outside the report and ensures attachment aliases—such as doubled or encoded slashes—always receive the sandboxed attachment policy. Reports stored in symlinked project directories remain supported.

Content-type detection and response delivery now use the same validated file handle, reducing path-replacement risks while preserving compatibility across supported operating systems and filesystems.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2