### PR TITLE
Ignore temporary files during Allure report generation

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
@@ -94,6 +94,8 @@ public class Allure2Plugin implements Reader {
 
     private static final String UNKNOWN_PARAMETER_VALUE = "#___unknown_value___#";
 
+    private static final String TEMPORARY_FILE_SUFFIX = ".tmp";
+
     private static final Pattern ATTACHMENT_SOURCE_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]{1,100}$");
 
     private static final Comparator<StageResult> BY_START = comparing(
@@ -344,7 +346,8 @@ public class Allure2Plugin implements Reader {
         final Path normalizedSource = source.normalize();
         final Path attachmentFile = normalizedSource.resolve(attachmentSource).normalize();
 
-        if (attachmentFile.startsWith(normalizedSource)
+        if (!attachmentSource.endsWith(TEMPORARY_FILE_SUFFIX)
+                && attachmentFile.startsWith(normalizedSource)
                 && Files.isRegularFile(attachmentFile, LinkOption.NOFOLLOW_LINKS)) {
             final Attachment found = visitor.visitAttachmentFile(attachmentFile);
             if (nonNull(attachment.getType())) {
@@ -503,6 +506,7 @@ public class Allure2Plugin implements Reader {
         try (DirectoryStream<Path> directoryStream = newDirectoryStream(directory, glob)) {
             return StreamSupport.stream(directoryStream.spliterator(), true)
                     .filter(Files::isRegularFile)
+                    .filter(path -> !path.getFileName().toString().endsWith(TEMPORARY_FILE_SUFFIX))
                     .collect(Collectors.toList())
                     .stream();
         } catch (IOException e) {

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -33,11 +33,14 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -171,6 +174,89 @@ class Allure2PluginTest {
                 .extracting(Attachment::getName)
                 .describedAs("Attachment's name is unexpected")
                 .containsExactly("String attachment in after");
+    }
+
+    /**
+     * Verifies ignoring unfinished Allure 2 result and container files.
+     */
+    @Description
+    @Test
+    void shouldIgnoreTemporaryResultAndContainerFiles() throws IOException {
+        final LaunchResults results = process(
+                "allure2/other-testcase.json", generateTestResultName(),
+                "allure2/flaky.json", generateTestResultName() + ".tmp",
+                "allure2/first-testgroup.json", generateTestResultContainerName() + ".tmp"
+        );
+
+        assertThat(results.getResults())
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.getName()).isEqualTo("shouldCreate");
+                    assertThat(result.getBeforeStages()).isEmpty();
+                    assertThat(result.getAfterStages()).isEmpty();
+                });
+    }
+
+    /**
+     * Verifies keeping links to unfinished Allure 2 attachments unresolved.
+     */
+    @Description
+    @Test
+    void shouldTreatTemporaryAttachmentFilesAsMissing() throws IOException {
+        final LaunchResults results = process(
+                "allure2/temporary-attachment.json", generateTestResultName(),
+                "allure2/test-sample-attachment.txt", ".allure-write-attachment.tmp"
+        );
+
+        assertThat(results.getResults())
+                .singleElement()
+                .satisfies(result -> {
+                    final StageResult stage = result.getTestStage();
+                    assertThat(stage).isNotNull();
+                    assertThat(stage.getAttachments())
+                            .extracting(
+                                    Attachment::getName,
+                                    Attachment::getType,
+                                    Attachment::getSource,
+                                    Attachment::getSize
+                            )
+                            .containsExactly(tuple("Unfinished attachment", "text/plain", null, 0L));
+                });
+        assertThat(results.getAttachments()).isEmpty();
+    }
+
+    /**
+     * Verifies treating attachment sources that resolve to a filesystem root as missing.
+     */
+    @Description
+    @Test
+    void shouldTreatRootAttachmentSourceAsMissing() throws IOException {
+        final Path archive = directory.resolve("results.zip");
+        try (FileSystem fileSystem = FileSystems.newFileSystem(archive, Map.of("create", "true"))) {
+            final Path resultsDirectory = fileSystem.getPath("/allure-results");
+            Files.createDirectory(resultsDirectory);
+            copyFile(resultsDirectory, "allure2/root-attachment-source.json", generateTestResultName());
+
+            final Allure2Plugin reader = new Allure2Plugin();
+            final Configuration configuration = ConfigurationBuilder.bundled().build();
+            final LaunchResults results = readResults(reader, configuration, resultsDirectory);
+
+            assertThat(results.getResults())
+                    .singleElement()
+                    .satisfies(result -> {
+                        final StageResult stage = result.getTestStage();
+                        assertThat(stage).isNotNull();
+                        assertThat(stage.getAttachments())
+                                .extracting(
+                                        Attachment::getName,
+                                        Attachment::getType,
+                                        Attachment::getSource,
+                                        Attachment::getSize
+                                )
+                                .containsExactly(tuple("Root attachment", "text/plain", null, 0L));
+                    });
+            assertThat(results.getAttachments()).isEmpty();
+        }
     }
 
     /**

--- a/allure-generator/src/test/resources/allure2/root-attachment-source.json
+++ b/allure-generator/src/test/resources/allure2/root-attachment-source.json
@@ -1,0 +1,13 @@
+{
+  "status": "passed",
+  "name": "shouldTreatRootAttachmentSourceAsMissing",
+  "start": 1479552611395,
+  "stop": 1479552611399,
+  "attachments": [
+    {
+      "name": "Root attachment",
+      "source": "..",
+      "type": "text/plain"
+    }
+  ]
+}

--- a/allure-generator/src/test/resources/allure2/temporary-attachment.json
+++ b/allure-generator/src/test/resources/allure2/temporary-attachment.json
@@ -1,0 +1,13 @@
+{
+  "status": "passed",
+  "name": "shouldIgnoreTemporaryAttachment",
+  "start": 1479552611395,
+  "stop": 1479552611399,
+  "attachments": [
+    {
+      "name": "Unfinished attachment",
+      "source": ".allure-write-attachment.tmp",
+      "type": "text/plain"
+    }
+  ]
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure Report now ignores files ending in `.tmp` when reading Allure 2 results. This supports integrations that write and sync temporary files before atomically renaming them, preventing incomplete results and containers from being processed.

If a completed result references a `.tmp` attachment, the reference remains visible as a missing file instead of reading transient content. Once the attachment is renamed to its final filename, it is processed normally.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2