### PR TITLE
Prevent excessive test name truncation in report trees

### DIFF
--- a/allure-generator/src/main/javascript/features/tree/views/TreeView.scss
+++ b/allure-generator/src/main/javascript/features/tree/views/TreeView.scss
@@ -26,6 +26,13 @@
     }
   }
   &__name {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+  &__text {
+    display: flex;
+    flex: 1 1 0;
+    gap: gap(1);
     min-width: 0;
   }
   &__unknown {
@@ -126,6 +133,7 @@
     padding: gap(1);
   }
   &__parameters {
+    flex: 1 1 10ch;
     padding: 0;
     color: var(--color-text-muted);
     min-width: 2ch;
@@ -170,4 +178,10 @@ allure-tree-view > .tree__content::after {
   content: "";
   display: block;
   height: var(--layout-scroll-end-padding);
+}
+
+@container side-by-side-left (max-width: 360px) {
+  .node__parameters {
+    display: none;
+  }
 }

--- a/allure-generator/src/main/javascript/features/tree/views/renderTreeView.mts
+++ b/allure-generator/src/main/javascript/features/tree/views/renderTreeView.mts
@@ -79,23 +79,25 @@ const createTreeLeaf = (
           text: `#${item.order}`,
         }),
         createElement("div", {
-          className: "node__name line-ellipsis",
-          text: item.name,
-        }),
-        item.parameters
-          ? createElement("div", {
-              className: "node__parameters long-line line-ellipsis",
-              children: item.parameters.flatMap((parameter) => [
-                parameter ?? "null",
-                createElement("span", {
-                  className: "node__parameters_separator",
-                  text: ",",
-                }),
-              ]),
-            })
-          : null,
-        createElement("div", {
-          className: "tree__strut",
+          className: "node__text",
+          children: [
+            createElement("div", {
+              className: "node__name line-ellipsis",
+              text: item.name,
+            }),
+            item.parameters
+              ? createElement("div", {
+                  className: "node__parameters long-line line-ellipsis",
+                  children: item.parameters.flatMap((parameter) => [
+                    parameter ?? "null",
+                    createElement("span", {
+                      className: "node__parameters_separator",
+                      text: ",",
+                    }),
+                  ]),
+                })
+              : null,
+          ],
         }),
         createMarkElement("flaky", Boolean(item.flaky)),
         createMarkElement("newFailed", Boolean(item.newFailed)),

--- a/allure-generator/src/main/javascript/shared/ui/styles/SideBySideView.scss
+++ b/allure-generator/src/main/javascript/shared/ui/styles/SideBySideView.scss
@@ -8,6 +8,10 @@
   position: absolute;
 }
 
+.side-by-side__left {
+  container: side-by-side-left / inline-size;
+}
+
 [dir="ltr"] .side-by-side {
   direction: ltr;
   flex-direction: row;

--- a/allure-generator/tests/e2e/support/fixtures.mts
+++ b/allure-generator/tests/e2e/support/fixtures.mts
@@ -144,9 +144,9 @@ export const fixtures = {
     name: "tree-long-name",
     caseName:
       "test_screenshot_default_games_section_with_a_descriptive_name_that_remains_long_enough_to_overflow_the_tree_row_even_on_wide_viewports",
-    parameters: [
-      "session[LivePage]",
-      "frontend.pages.screenshot.default.games.section",
-    ],
+    shortCaseName: "SpreadSheet export",
+    parameters: ["session[LivePage]", "frontend.pages.screenshot.default.games.section"],
+    longParameter:
+      "frontend.pages.spreadsheets.quarterly.exports.with.a.parameter.value.that.is.long.enough.to.use.the.remaining.tree.row.space",
   },
 } as const;

--- a/allure-generator/tests/e2e/tree.layout.spec.mts
+++ b/allure-generator/tests/e2e/tree.layout.spec.mts
@@ -3,6 +3,7 @@ import { fixtures, REPORT_MODES } from "./support/fixtures.mts";
 import { openCaseFromTree } from "./support/report.mts";
 
 const fixture = fixtures.treeLongName;
+const parametersHiddenPaneWidth = 360;
 
 test.describe("Tree layout", () => {
   test("ellipsizes long test names before parameter text", async ({ page }, testInfo) => {
@@ -73,5 +74,130 @@ test.describe("Tree layout", () => {
     await expect(name).toHaveCSS("overflow-x", "hidden");
     await expect(name).toHaveCSS("text-overflow", "ellipsis");
     await expect(name).toHaveCSS("white-space", "nowrap");
+  });
+
+  test("lets parameters use the remaining space beside a short name", async ({
+    page,
+  }, testInfo) => {
+    await openCaseFromTree(page, {
+      fixture: fixture.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: fixture.shortCaseName,
+    });
+
+    const title = page.locator(".node__title_active");
+    const name = title.locator(".node__name");
+    const parameters = title.locator(".node__parameters");
+    await expect(name).toHaveText(fixture.shortCaseName);
+    await expect(parameters).toContainText(fixture.longParameter);
+
+    const layout = await title.evaluate((element) => {
+      const nameElement = element.querySelector<HTMLElement>(".node__name");
+      const parameterElement = element.querySelector<HTMLElement>(".node__parameters");
+      const statsElement = element.querySelector<HTMLElement>(".node__stats");
+      if (!nameElement || !parameterElement || !statsElement) {
+        throw new Error("Expected the selected tree row to contain name, parameters, and stats");
+      }
+
+      const parameterBox = parameterElement.getBoundingClientRect();
+      const statsBox = statsElement.getBoundingClientRect();
+
+      return {
+        titleWidth: element.getBoundingClientRect().width,
+        nameClientWidth: nameElement.clientWidth,
+        nameScrollWidth: nameElement.scrollWidth,
+        parametersClientWidth: parameterElement.clientWidth,
+        parametersScrollWidth: parameterElement.scrollWidth,
+        trailingGap: statsBox.left - parameterBox.right,
+        parametersDisplay: getComputedStyle(parameterElement).display,
+      };
+    });
+
+    await testInfo.attach("Short-name tree row layout", {
+      body: Buffer.from(JSON.stringify(layout, null, 2)),
+      contentType: "application/json",
+    });
+    await testInfo.attach("Short-name tree row screenshot", {
+      body: await title.screenshot(),
+      contentType: "image/png",
+    });
+
+    expect(
+      layout.nameClientWidth,
+      "A short test name should remain fully visible next to oversized parameters",
+    ).toBeGreaterThanOrEqual(layout.nameScrollWidth);
+    expect(
+      layout.parametersScrollWidth,
+      "The fixture must force the parameter text to overflow its allocated space",
+    ).toBeGreaterThan(layout.parametersClientWidth);
+    expect(
+      layout.trailingGap,
+      "The parameter area should use the row space available before the duration",
+    ).toBeLessThanOrEqual(16);
+    expect(layout.parametersDisplay).not.toBe("none");
+  });
+
+  test("hides parameters when the tree pane is narrower than 360px", async ({ page }, testInfo) => {
+    await openCaseFromTree(page, {
+      fixture: fixture.name,
+      mode: REPORT_MODES.DIRECTORY,
+      tab: "suites",
+      caseName: fixture.shortCaseName,
+    });
+
+    const title = page.locator(".node__title_active");
+    const name = title.locator(".node__name");
+    const parameters = title.locator(".node__parameters");
+    await expect(parameters).toBeVisible();
+
+    await page.locator("allure-side-by-side").evaluate((element, targetWidth) => {
+      const layout = element as HTMLElement & {
+        splitter?: { setSizes: (sizes: number[]) => void };
+      };
+      if (!layout.splitter) {
+        throw new Error("Expected the side-by-side splitter to be initialized");
+      }
+
+      const totalWidth = layout.getBoundingClientRect().width;
+      const leftPercent = (targetWidth / totalWidth) * 100;
+      layout.splitter.setSizes([leftPercent, 100 - leftPercent]);
+    }, parametersHiddenPaneWidth - 20);
+
+    const leftPane = page.locator(".side-by-side__left");
+    await expect
+      .poll(() => leftPane.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeLessThan(parametersHiddenPaneWidth);
+    await expect(parameters).toBeHidden();
+    await expect(name).toBeVisible();
+
+    const layout = await title.evaluate((element) => {
+      const leftPane = document.querySelector<HTMLElement>(".side-by-side__left");
+      const nameElement = element.querySelector<HTMLElement>(".node__name");
+      const parameterElement = element.querySelector<HTMLElement>(".node__parameters");
+      if (!leftPane || !nameElement || !parameterElement) {
+        throw new Error("Expected the tree pane and selected tree row to be rendered");
+      }
+
+      return {
+        paneWidth: leftPane.getBoundingClientRect().width,
+        nameClientWidth: nameElement.clientWidth,
+        nameScrollWidth: nameElement.scrollWidth,
+        parametersDisplay: getComputedStyle(parameterElement).display,
+      };
+    });
+
+    await testInfo.attach("Narrow tree pane layout", {
+      body: Buffer.from(JSON.stringify(layout, null, 2)),
+      contentType: "application/json",
+    });
+    await testInfo.attach("Narrow tree pane screenshot", {
+      body: await title.screenshot(),
+      contentType: "image/png",
+    });
+
+    expect(layout.paneWidth).toBeLessThan(parametersHiddenPaneWidth);
+    expect(layout.parametersDisplay).toBe("none");
+    expect(layout.nameClientWidth).toBeGreaterThanOrEqual(layout.nameScrollWidth);
   });
 });

--- a/allure-generator/tests/fixtures/raw/tree-long-name/tree-short-name-result.json
+++ b/allure-generator/tests/fixtures/raw/tree-long-name/tree-short-name-result.json
@@ -1,0 +1,54 @@
+{
+  "uuid": "tree-short-name-result",
+  "historyId": "tree-short-name-history",
+  "name": "SpreadSheet export",
+  "fullName": "frontend.pages.SpreadSheetTest.SpreadSheet export",
+  "status": "passed",
+  "stage": "finished",
+  "description": "Regression fixture for a short tree name next to oversized parameter text.",
+  "start": 1710000020000,
+  "stop": 1710000025000,
+  "steps": [],
+  "attachments": [],
+  "parameters": [
+    {
+      "name": "source",
+      "value": "frontend.pages.spreadsheets.quarterly.exports.with.a.parameter.value.that.is.long.enough.to.use.the.remaining.tree.row.space"
+    }
+  ],
+  "labels": [
+    {
+      "name": "suite",
+      "value": "TestScreenshotMainPageDefaultGamesSection"
+    },
+    {
+      "name": "package",
+      "value": "frontend.pages"
+    },
+    {
+      "name": "testClass",
+      "value": "SpreadSheetTest"
+    },
+    {
+      "name": "testMethod",
+      "value": "SpreadSheet export"
+    },
+    {
+      "name": "framework",
+      "value": "pytest"
+    },
+    {
+      "name": "language",
+      "value": "python"
+    },
+    {
+      "name": "host",
+      "value": "localhost"
+    },
+    {
+      "name": "thread",
+      "value": "main"
+    }
+  ],
+  "links": []
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Test case names in Suites, Behaviors, and Packages are no longer squeezed to only a few characters by long parameter values. Short names such as `SpreadSheet export` remain fully visible, while long names and parameters still truncate cleanly when space is limited.

In tree panes that are 360px wide or narrower, parameter text is hidden so the test name and duration remain readable.

fixes #3458

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2