### PR TITLE
Support run-level errors and attachments in Allure 2 reports

### DIFF
--- a/allure-generator/scripts/prepare-playwright-report.mts
+++ b/allure-generator/scripts/prepare-playwright-report.mts
@@ -32,6 +32,10 @@ export const DEFAULT_REPORTS: ReportRequest[] = [
   { fixture: "playwright-trace", mode: REPORT_MODES.SINGLE_FILE },
   { fixture: "playwright-trace", mode: REPORT_MODES.DIRECTORY },
   { fixture: "tree-long-name", mode: REPORT_MODES.DIRECTORY },
+  { fixture: "globals-green", mode: REPORT_MODES.SINGLE_FILE },
+  { fixture: "globals-green", mode: REPORT_MODES.DIRECTORY },
+  { fixture: "globals-no-tests", mode: REPORT_MODES.DIRECTORY },
+  { fixture: "globals-attachments", mode: REPORT_MODES.DIRECTORY },
 ];
 
 const gradleWrapper = path.join(repoRoot, process.platform === "win32" ? "gradlew.bat" : "gradlew");
@@ -147,7 +151,7 @@ export default async function preparePlaywrightReport({
 if (process.argv[1] && path.resolve(process.argv[1]) === moduleFilename) {
   void preparePlaywrightReport({ reports: parseCliReports(process.argv.slice(2)) }).catch(
     (error: unknown) => {
-      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
       process.stderr.write(`${message}\n`);
       process.exit(1);
     },

--- a/allure-generator/src/main/java/io/qameta/allure/ConfigurationBuilder.java
+++ b/allure-generator/src/main/java/io/qameta/allure/ConfigurationBuilder.java
@@ -34,6 +34,7 @@ import io.qameta.allure.duration.DurationTrendPlugin;
 import io.qameta.allure.environment.Allure1EnvironmentPlugin;
 import io.qameta.allure.executor.ExecutorPlugin;
 import io.qameta.allure.ga.GaPlugin;
+import io.qameta.allure.globals.GlobalsPlugin;
 import io.qameta.allure.history.HistoryPlugin;
 import io.qameta.allure.history.HistoryTrendPlugin;
 import io.qameta.allure.idea.IdeaLinksPlugin;
@@ -96,6 +97,7 @@ public class ConfigurationBuilder {
             new SuitesPlugin(),
             new TestsResultsPlugin(),
             new AttachmentsPlugin(),
+            new GlobalsPlugin(),
             new MailPlugin(),
             new InfluxDbExportPlugin(),
             new PrometheusExportPlugin(),
@@ -173,6 +175,7 @@ public class ConfigurationBuilder {
                         new SuitesPlugin(),
                         new TestsResultsPlugin(),
                         new AttachmentsPlugin(),
+                        new GlobalsPlugin(),
                         new MailPlugin(),
                         new InfluxDbExportPlugin(),
                         new PrometheusExportPlugin(),

--- a/allure-generator/src/main/java/io/qameta/allure/DefaultLaunchResults.java
+++ b/allure-generator/src/main/java/io/qameta/allure/DefaultLaunchResults.java
@@ -17,9 +17,13 @@ package io.qameta.allure;
 
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.TestResult;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,12 +42,26 @@ public class DefaultLaunchResults implements LaunchResults {
 
     private final Map<String, Object> extra;
 
+    private final List<GlobalError> globalErrors;
+
+    private final List<GlobalAttachment> globalAttachments;
+
     public DefaultLaunchResults(final Set<TestResult> results,
                                 final Map<Path, Attachment> attachments,
                                 final Map<String, Object> extra) {
+        this(results, attachments, extra, Collections.emptyList(), Collections.emptyList());
+    }
+
+    public DefaultLaunchResults(final Set<TestResult> results,
+                                final Map<Path, Attachment> attachments,
+                                final Map<String, Object> extra,
+                                final List<GlobalError> globalErrors,
+                                final List<GlobalAttachment> globalAttachments) {
         this.results = results;
         this.attachments = attachments;
         this.extra = extra;
+        this.globalErrors = globalErrors;
+        this.globalAttachments = globalAttachments;
     }
 
     @Override
@@ -54,6 +72,16 @@ public class DefaultLaunchResults implements LaunchResults {
     @Override
     public Map<Path, Attachment> getAttachments() {
         return attachments;
+    }
+
+    @Override
+    public List<GlobalError> getGlobalErrors() {
+        return globalErrors;
+    }
+
+    @Override
+    public List<GlobalAttachment> getGlobalAttachments() {
+        return globalAttachments;
     }
 
     @Override

--- a/allure-generator/src/main/java/io/qameta/allure/DefaultResultsVisitor.java
+++ b/allure-generator/src/main/java/io/qameta/allure/DefaultResultsVisitor.java
@@ -22,6 +22,8 @@ import io.qameta.allure.core.ResultsVisitor;
 import io.qameta.allure.detect.ContentTypeDetector;
 import io.qameta.allure.detect.WellKnownFileExtensionsUtils;
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.Parameter;
 import io.qameta.allure.entity.TestResult;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -33,14 +35,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import static java.nio.file.Files.newInputStream;
@@ -87,11 +92,17 @@ public class DefaultResultsVisitor implements ResultsVisitor {
 
     private final Map<String, Object> extra;
 
+    private final Queue<GlobalError> globalErrors;
+
+    private final Queue<GlobalAttachment> globalAttachments;
+
     public DefaultResultsVisitor(final Configuration configuration) {
         this.configuration = configuration;
         this.results = ConcurrentHashMap.newKeySet();
         this.attachments = new ConcurrentHashMap<>();
         this.extra = new ConcurrentHashMap<>();
+        this.globalErrors = new ConcurrentLinkedQueue<>();
+        this.globalAttachments = new ConcurrentLinkedQueue<>();
     }
 
     @Override
@@ -126,6 +137,16 @@ public class DefaultResultsVisitor implements ResultsVisitor {
                         .setTestCaseHash(testCaseHash)
                         .setParametersHash(parametersHash)
         );
+    }
+
+    @Override
+    public void visitGlobalError(final GlobalError error) {
+        globalErrors.add(error);
+    }
+
+    @Override
+    public void visitGlobalAttachment(final GlobalAttachment attachment) {
+        globalAttachments.add(attachment);
     }
 
     private static String getTestCaseHash(final TestResult result) {
@@ -175,7 +196,9 @@ public class DefaultResultsVisitor implements ResultsVisitor {
         return new DefaultLaunchResults(
                 Collections.unmodifiableSet(results),
                 Collections.unmodifiableMap(attachments),
-                Collections.unmodifiableMap(extra)
+                Collections.unmodifiableMap(extra),
+                Collections.unmodifiableList(new ArrayList<>(globalErrors)),
+                Collections.unmodifiableList(new ArrayList<>(globalAttachments))
         );
     }
 

--- a/allure-generator/src/main/java/io/qameta/allure/DummyReportGenerator.java
+++ b/allure-generator/src/main/java/io/qameta/allure/DummyReportGenerator.java
@@ -32,6 +32,7 @@ import io.qameta.allure.duration.DurationPlugin;
 import io.qameta.allure.duration.DurationTrendPlugin;
 import io.qameta.allure.environment.Allure1EnvironmentPlugin;
 import io.qameta.allure.executor.ExecutorPlugin;
+import io.qameta.allure.globals.GlobalsPlugin;
 import io.qameta.allure.history.HistoryPlugin;
 import io.qameta.allure.history.HistoryTrendPlugin;
 import io.qameta.allure.idea.IdeaLinksPlugin;
@@ -93,6 +94,7 @@ public final class DummyReportGenerator {
             new SuitesPlugin(),
             new TestsResultsPlugin(),
             new AttachmentsPlugin(),
+            new GlobalsPlugin(),
             new MailPlugin(),
             new InfluxDbExportPlugin(),
             new PrometheusExportPlugin(),

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Globals.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Globals.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.allure2;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Allure 2 run-level data stored in {@code *-globals.json} files.
+ */
+@Data
+@Accessors(chain = true)
+class Allure2Globals {
+
+    private List<Error> errors = new ArrayList<>();
+    private List<Attachment> attachments = new ArrayList<>();
+
+    @Data
+    @Accessors(chain = true)
+    static class Error {
+        private Long timestamp;
+        private String message;
+        private String trace;
+        private String actual;
+        private String expected;
+    }
+
+    @Data
+    @Accessors(chain = true)
+    static class Attachment {
+        private String name;
+        private String type;
+        private String source;
+    }
+
+}

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Globals.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Globals.java
@@ -44,6 +44,7 @@ class Allure2Globals {
     @Data
     @Accessors(chain = true)
     static class Attachment {
+        private Long timestamp;
         private String name;
         private String type;
         private String source;

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
@@ -74,12 +74,14 @@ class Allure2GlobalsReader {
                 .orElseGet(ArrayList::new)
                 .stream()
                 .filter(Objects::nonNull)
-                .map(error -> new GlobalError()
-                        .setTimestamp(error.getTimestamp())
-                        .setMessage(error.getMessage())
-                        .setTrace(error.getTrace())
-                        .setActual(error.getActual())
-                        .setExpected(error.getExpected()))
+                .map(
+                        error -> new GlobalError()
+                                .setTimestamp(error.getTimestamp())
+                                .setMessage(error.getMessage())
+                                .setTrace(error.getTrace())
+                                .setActual(error.getActual())
+                                .setExpected(error.getExpected())
+                )
                 .forEach(visitor::visitGlobalError);
 
         Optional.ofNullable(globals.getAttachments())
@@ -116,12 +118,14 @@ class Allure2GlobalsReader {
             }
         }
 
-        visitor.visitGlobalAttachment(new GlobalAttachment()
-                .setUid(stored.getUid())
-                .setName(Optional.ofNullable(attachment.getName()).orElse(stored.getName()))
-                .setSource(stored.getSource())
-                .setType(stored.getType())
-                .setSize(stored.getSize()));
+        visitor.visitGlobalAttachment(
+                new GlobalAttachment()
+                        .setUid(stored.getUid())
+                        .setName(Optional.ofNullable(attachment.getName()).orElse(stored.getName()))
+                        .setSource(stored.getSource())
+                        .setType(stored.getType())
+                        .setSize(stored.getSize())
+        );
     }
 
     private Optional<Allure2Globals> readGlobalsFile(final Path file) {

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
@@ -120,6 +120,7 @@ class Allure2GlobalsReader {
 
         visitor.visitGlobalAttachment(
                 new GlobalAttachment()
+                        .setTimestamp(attachment.getTimestamp())
                         .setUid(stored.getUid())
                         .setName(Optional.ofNullable(attachment.getName()).orElse(stored.getName()))
                         .setSource(stored.getSource())

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2GlobalsReader.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.allure2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.core.ResultsVisitor;
+import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static io.qameta.allure.detect.WellKnownFileExtensionsUtils.getExtensionByMimeType;
+import static java.nio.file.Files.newDirectoryStream;
+import static java.util.Objects.nonNull;
+
+/**
+ * Reads run-level errors and attachments from Allure 2 globals files.
+ */
+class Allure2GlobalsReader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Allure2GlobalsReader.class);
+
+    private static final String TEMPORARY_FILE_SUFFIX = ".tmp";
+
+    private static final Pattern ATTACHMENT_SOURCE_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]{1,100}$");
+
+    private final ObjectMapper mapper;
+
+    Allure2GlobalsReader(final ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    void readResults(final ResultsVisitor visitor, final Path resultsDirectory) {
+        listFiles(resultsDirectory)
+                .sorted()
+                .map(this::readGlobalsFile)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(globals -> processGlobals(resultsDirectory, visitor, globals));
+    }
+
+    private void processGlobals(final Path resultsDirectory,
+                                final ResultsVisitor visitor,
+                                final Allure2Globals globals) {
+        Optional.ofNullable(globals.getErrors())
+                .orElseGet(ArrayList::new)
+                .stream()
+                .filter(Objects::nonNull)
+                .map(error -> new GlobalError()
+                        .setTimestamp(error.getTimestamp())
+                        .setMessage(error.getMessage())
+                        .setTrace(error.getTrace())
+                        .setActual(error.getActual())
+                        .setExpected(error.getExpected()))
+                .forEach(visitor::visitGlobalError);
+
+        Optional.ofNullable(globals.getAttachments())
+                .orElseGet(ArrayList::new)
+                .stream()
+                .filter(Objects::nonNull)
+                .forEach(attachment -> processGlobalAttachment(resultsDirectory, visitor, attachment));
+    }
+
+    private void processGlobalAttachment(final Path resultsDirectory,
+                                         final ResultsVisitor visitor,
+                                         final Allure2Globals.Attachment attachment) {
+        final String attachmentSource = attachment.getSource();
+        if (!isValidAttachmentFileName(attachmentSource)) {
+            visitor.error("Invalid global attachment source is provided: " + attachmentSource);
+            return;
+        }
+
+        final Path normalizedSource = resultsDirectory.normalize();
+        final Path attachmentFile = normalizedSource.resolve(attachmentSource).normalize();
+        if (attachmentSource.endsWith(TEMPORARY_FILE_SUFFIX)
+                || !attachmentFile.startsWith(normalizedSource)
+                || !Files.isRegularFile(attachmentFile, LinkOption.NOFOLLOW_LINKS)) {
+            visitor.error("Could not find global attachment " + attachmentSource + " in directory " + normalizedSource);
+            return;
+        }
+
+        final Attachment stored = visitor.visitAttachmentFile(attachmentFile);
+        if (nonNull(attachment.getType())) {
+            stored.setType(attachment.getType());
+            final String ext = getExtensionByMimeType(attachment.getType());
+            if (!ext.isEmpty()) {
+                stored.setSource(stored.getUid() + "." + ext);
+            }
+        }
+
+        visitor.visitGlobalAttachment(new GlobalAttachment()
+                .setUid(stored.getUid())
+                .setName(Optional.ofNullable(attachment.getName()).orElse(stored.getName()))
+                .setSource(stored.getSource())
+                .setType(stored.getType())
+                .setSize(stored.getSize()));
+    }
+
+    private Optional<Allure2Globals> readGlobalsFile(final Path file) {
+        try (InputStream is = Files.newInputStream(file)) {
+            return Optional.ofNullable(mapper.readValue(is, Allure2Globals.class));
+        } catch (IOException e) {
+            LOGGER.error("Could not read globals file {}", file, e);
+            return Optional.empty();
+        }
+    }
+
+    private Stream<Path> listFiles(final Path directory) {
+        try (DirectoryStream<Path> directoryStream = newDirectoryStream(directory, "*-globals.json")) {
+            return StreamSupport.stream(directoryStream.spliterator(), false)
+                    .filter(Files::isRegularFile)
+                    .filter(path -> !path.getFileName().toString().endsWith(TEMPORARY_FILE_SUFFIX))
+                    .collect(Collectors.toList())
+                    .stream();
+        } catch (IOException e) {
+            LOGGER.error("Could not list globals files in directory {}", directory, e);
+            return Stream.empty();
+        }
+    }
+
+    private static boolean isValidAttachmentFileName(final String fileName) {
+        return nonNull(fileName) && ATTACHMENT_SOURCE_PATTERN.matcher(fileName).matches();
+    }
+
+}

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
@@ -169,6 +169,8 @@ public class Allure2Plugin implements Reader {
                                 befores, afters
                         )
                 );
+
+        new Allure2GlobalsReader(mapper).readResults(visitor, resultsDirectory);
     }
 
     private static void sortByStart(final Map<String, List<StageResult>> befores) {

--- a/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsData.java
+++ b/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsData.java
@@ -17,23 +17,33 @@ package io.qameta.allure.globals;
 
 import io.qameta.allure.entity.GlobalAttachment;
 import io.qameta.allure.entity.GlobalError;
-import lombok.Data;
-import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Browser-facing run-level errors and attachments.
  */
-@Data
-@Accessors(chain = true)
 public class GlobalsData implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    protected List<GlobalError> errors = new ArrayList<>();
-    protected List<GlobalAttachment> attachments = new ArrayList<>();
+    private final List<GlobalError> errors;
+    private final List<GlobalAttachment> attachments;
+
+    public GlobalsData(final List<GlobalError> errors, final List<GlobalAttachment> attachments) {
+        this.errors = new ArrayList<>(errors);
+        this.attachments = new ArrayList<>(attachments);
+    }
+
+    public List<GlobalError> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+    public List<GlobalAttachment> getAttachments() {
+        return Collections.unmodifiableList(attachments);
+    }
 
 }

--- a/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsData.java
+++ b/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsData.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.globals;
+
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Browser-facing run-level errors and attachments.
+ */
+@Data
+@Accessors(chain = true)
+public class GlobalsData implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected List<GlobalError> errors = new ArrayList<>();
+    protected List<GlobalAttachment> attachments = new ArrayList<>();
+
+}

--- a/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsPlugin.java
@@ -22,9 +22,11 @@ import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.Attachment;
 import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Generates the run-level data consumed by the report UI.
@@ -37,15 +39,17 @@ public class GlobalsPlugin implements Aggregator2 {
     public void aggregate(final Configuration configuration,
                           final List<LaunchResults> launchesResults,
                           final ReportStorage storage) {
-        final GlobalsData data = new GlobalsData();
-        launchesResults.forEach(launch -> {
-            data.getErrors().addAll(launch.getGlobalErrors());
-            launch.getGlobalAttachments().stream()
-                    .filter(attachment -> hasContent(launch, attachment))
-                    .forEach(data.getAttachments()::add);
-        });
+        final List<GlobalError> errors = launchesResults.stream()
+                .flatMap(launch -> launch.getGlobalErrors().stream())
+                .collect(Collectors.toList());
+        final List<GlobalAttachment> attachments = launchesResults.stream()
+                .flatMap(
+                        launch -> launch.getGlobalAttachments().stream()
+                                .filter(attachment -> hasContent(launch, attachment))
+                )
+                .collect(Collectors.toList());
 
-        storage.addDataJson(Constants.widgetsPath(JSON_FILE_NAME), data);
+        storage.addDataJson(Constants.widgetsPath(JSON_FILE_NAME), new GlobalsData(errors, attachments));
     }
 
     private static boolean hasContent(final LaunchResults launch, final GlobalAttachment globalAttachment) {

--- a/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/globals/GlobalsPlugin.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.globals;
+
+import io.qameta.allure.Aggregator2;
+import io.qameta.allure.Constants;
+import io.qameta.allure.ReportStorage;
+import io.qameta.allure.core.Configuration;
+import io.qameta.allure.core.LaunchResults;
+import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Generates the run-level data consumed by the report UI.
+ */
+public class GlobalsPlugin implements Aggregator2 {
+
+    public static final String JSON_FILE_NAME = "globals.json";
+
+    @Override
+    public void aggregate(final Configuration configuration,
+                          final List<LaunchResults> launchesResults,
+                          final ReportStorage storage) {
+        final GlobalsData data = new GlobalsData();
+        launchesResults.forEach(launch -> {
+            data.getErrors().addAll(launch.getGlobalErrors());
+            launch.getGlobalAttachments().stream()
+                    .filter(attachment -> hasContent(launch, attachment))
+                    .forEach(data.getAttachments()::add);
+        });
+
+        storage.addDataJson(Constants.widgetsPath(JSON_FILE_NAME), data);
+    }
+
+    private static boolean hasContent(final LaunchResults launch, final GlobalAttachment globalAttachment) {
+        return launch.getAttachments().values().stream()
+                .map(Attachment::getSource)
+                .anyMatch(source -> Objects.equals(source, globalAttachment.getSource()));
+    }
+
+}

--- a/allure-generator/src/main/javascript/core/registry/index.mts
+++ b/allure-generator/src/main/javascript/core/registry/index.mts
@@ -7,6 +7,7 @@ import {
   widgetsByTab as overviewWidgets,
 } from "../../features/overview/index.mts";
 import { packagesTab } from "../../features/packages/index.mts";
+import { runTab } from "../../features/run/index.mts";
 import { suitesTab } from "../../features/suites/index.mts";
 import { testResultBlocks, testResultTabs } from "../../features/test-result/index.mts";
 import { timelineTab } from "../../features/timeline/index.mts";
@@ -34,6 +35,7 @@ const defaultAvailability: AvailabilityResolver = () => true;
 
 const tabs: TabDescriptor[] = [
   overviewTab,
+  runTab,
   categoriesTab,
   suitesTab,
   behaviorsTab,

--- a/allure-generator/src/main/javascript/features/attachments/views/renderAttachmentRow.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/renderAttachmentRow.mts
@@ -9,7 +9,14 @@ import attachmentType from "../model/attachmentType.mts";
 
 type Attachment = import("../../../types/report.mts").Attachment;
 
-export const createAttachmentRow = ({ uid, type, name, source, size }: Attachment) => {
+type AttachmentRowOptions = {
+  details?: string;
+};
+
+export const createAttachmentRow = (
+  { uid, type, name, source, size }: Attachment,
+  { details }: AttachmentRowOptions = {},
+) => {
   const attachmentInfo = attachmentType(type || "");
   const isTraceAttachment = attachmentInfo.view === AttachmentPreviewView.PlaywrightTrace;
 
@@ -42,8 +49,19 @@ export const createAttachmentRow = ({ uid, type, name, source, size }: Attachmen
             }),
           }),
           createElement("div", {
-            className: "attachment-row__name long-line",
-            text: name || source,
+            className: "attachment-row__label",
+            children: [
+              createElement("div", {
+                className: "attachment-row__name long-line",
+                text: name || source,
+              }),
+              details
+                ? createElement("div", {
+                    className: "attachment-row__details",
+                    text: details,
+                  })
+                : null,
+            ],
           }),
           createElement("div", {
             className: "attachment-row__control attachment-row__link",

--- a/allure-generator/src/main/javascript/features/attachments/views/renderAttachmentRow.mts
+++ b/allure-generator/src/main/javascript/features/attachments/views/renderAttachmentRow.mts
@@ -1,0 +1,88 @@
+import fileicon from "../../../helpers/fileicon.mts";
+import filesize from "../../../helpers/filesize.mts";
+import translate from "../../../helpers/t.mts";
+import b from "../../../shared/bem/index.mts";
+import { createElement } from "../../../shared/dom.mts";
+import { createIconElement } from "../../../shared/icon/index.mts";
+import { AttachmentPreviewView } from "../model/attachmentPreviewView.mts";
+import attachmentType from "../model/attachmentType.mts";
+
+type Attachment = import("../../../types/report.mts").Attachment;
+
+export const createAttachmentRow = ({ uid, type, name, source, size }: Attachment) => {
+  const attachmentInfo = attachmentType(type || "");
+  const isTraceAttachment = attachmentInfo.view === AttachmentPreviewView.PlaywrightTrace;
+
+  return createElement("div", {
+    children: [
+      createElement("div", {
+        attrs: {
+          "data-type": type,
+          "data-uid": uid,
+          ...(isTraceAttachment ? { "data-viewer": "playwright-trace" } : {}),
+        },
+        className: "attachment-row",
+        children: [
+          createElement("span", {
+            className: "attachment-row__arrow block__arrow",
+            children: createIconElement(
+              isTraceAttachment ? "lineGeneralLinkExternal" : "lineArrowsChevronRight",
+              {
+                className: "angle",
+                size: "s",
+              },
+            ),
+          }),
+          createElement("div", {
+            attrs: type ? { "data-tooltip": type } : {},
+            className: "attachment-row__icon",
+            children: createIconElement(fileicon(type), {
+              size: "s",
+              title: type || "",
+            }),
+          }),
+          createElement("div", {
+            className: "attachment-row__name long-line",
+            text: name || source,
+          }),
+          createElement("div", {
+            className: "attachment-row__control attachment-row__link",
+            children: createElement("div", {
+              attrs: {
+                "data-download": `data/attachments/${source}`,
+                "data-download-target": "_blank",
+                "data-download-type": type,
+                "data-tooltip": translate("testResult.execution.downloadAttachment.tooltip"),
+              },
+              className: "link",
+              children: [
+                createIconElement("lineGeneralDownloadCloud", {
+                  inline: true,
+                  size: "s",
+                }),
+                " ",
+                filesize(size),
+              ],
+            }),
+          }),
+          createElement("div", {
+            className: "attachment-row__control attachment-row__fullscreen",
+            children: createElement("a", {
+              className: "link",
+              children: createIconElement("lineLayoutsMaximize2", {
+                inline: true,
+                size: "s",
+              }),
+            }),
+          }),
+        ],
+      }),
+      createElement("div", {
+        className: "attachment-row__preview",
+        children: createElement("div", {
+          className: `attachment-row__content ${b("attachment", String(uid))}`,
+        }),
+      }),
+    ],
+  });
+};

--- a/allure-generator/src/main/javascript/features/overview/OverviewLayout.mts
+++ b/allure-generator/src/main/javascript/features/overview/OverviewLayout.mts
@@ -1,9 +1,28 @@
 import AppLayout from "../shell/AppLayout.mts";
+import { fetchReportJson } from "../../core/services/reportData.mts";
+import { loadGlobalsData } from "../run/model/globalsData.mts";
+import RunStatusBannerView from "../run/views/RunStatusBannerView.mts";
 import WidgetsGridView from "./WidgetsGridView.mts";
 
 export default function OverviewLayout(options: Record<string, unknown>) {
+  let globals: import("../../types/report.mts").GlobalsData = {
+    errors: [],
+    attachments: [],
+  };
+  let summary: import("../../types/report.mts").SummaryData = {};
+
   return AppLayout({
     ...options,
-    createContentView: () => WidgetsGridView({ tabName: "widgets" }),
+    loadData: async () => {
+      [globals, summary] = await Promise.all([
+        loadGlobalsData(),
+        fetchReportJson<import("../../types/report.mts").SummaryData>("widgets/summary.json"),
+      ]);
+    },
+    createContentView: () =>
+      WidgetsGridView({
+        tabName: "widgets",
+        header: globals.errors.length ? RunStatusBannerView({ globals, summary }) : undefined,
+      }),
   });
 }

--- a/allure-generator/src/main/javascript/features/overview/WidgetsGridView.mts
+++ b/allure-generator/src/main/javascript/features/overview/WidgetsGridView.mts
@@ -3,10 +3,12 @@ import BaseElement from "../../core/elements/BaseElement.mts";
 import { getWidgets } from "../../core/registry/index.mts";
 import { getSettingsForWidgetGridPlugin } from "../../core/services/settings.mts";
 import { createReportLoadErrorView } from "../../core/view/asyncMount.mts";
+import type { Mountable } from "../../core/view/types.mts";
 import { createElement } from "../../shared/dom.mts";
 import LoaderView from "../../shared/ui/LoaderView.mts";
 
 type WidgetsGridOptions = {
+  header?: Mountable;
   tabName: string;
   settings?: ReturnType<typeof getSettingsForWidgetGridPlugin>;
 };
@@ -74,6 +76,12 @@ class WidgetsGridElement extends BaseElement {
       },
       this,
     );
+
+    if (this.options.header) {
+      const header = createElement("div", { className: "widgets-grid__header" });
+      this.appendChild(header);
+      this.mountChild("header", this.options.header, header);
+    }
 
     this.getWidgetsArrangement().forEach((widgetNames) => {
       const col = createElement("div", { className: "widgets-grid__col" });

--- a/allure-generator/src/main/javascript/features/overview/WidgetsGridView.scss
+++ b/allure-generator/src/main/javascript/features/overview/WidgetsGridView.scss
@@ -11,6 +11,11 @@ $widgets-grid-column-min-width: 304px;
   max-height: 100%;
   overflow: auto;
   display: flex;
+  flex-wrap: wrap;
+  &__header {
+    flex: 0 0 100%;
+    width: 100%;
+  }
   &__col {
     flex: 1 0 0%;
     width: 50%;
@@ -26,6 +31,9 @@ $widgets-grid-column-min-width: 304px;
 @media (max-width: $breakpoint-medium) {
   .widgets-grid {
     display: block;
+    &__header {
+      margin-bottom: gap(3);
+    }
     &__col {
       width: 100%;
     }

--- a/allure-generator/src/main/javascript/features/run/RunLayout.mts
+++ b/allure-generator/src/main/javascript/features/run/RunLayout.mts
@@ -1,0 +1,18 @@
+import AppLayout from "../shell/AppLayout.mts";
+import { loadGlobalsData } from "./model/globalsData.mts";
+import RunView from "./views/RunView.mts";
+
+export default function RunLayout(options: Record<string, unknown> = {}) {
+  let data: import("../../types/report.mts").GlobalsData = {
+    errors: [],
+    attachments: [],
+  };
+
+  return AppLayout({
+    ...options,
+    loadData: async () => {
+      data = await loadGlobalsData();
+    },
+    createContentView: () => RunView({ data }),
+  });
+}

--- a/allure-generator/src/main/javascript/features/run/index.mts
+++ b/allure-generator/src/main/javascript/features/run/index.mts
@@ -1,0 +1,11 @@
+import RunLayout from "./RunLayout.mts";
+
+type TabDescriptor = import("../../core/registry/types.mts").TabDescriptor;
+
+export const runTab: TabDescriptor = {
+  tabName: "run",
+  title: "tab.run.name",
+  icon: "lineGeneralInfoCircle",
+  route: "run",
+  onEnter: () => RunLayout(),
+};

--- a/allure-generator/src/main/javascript/features/run/model/globalsData.mts
+++ b/allure-generator/src/main/javascript/features/run/model/globalsData.mts
@@ -1,0 +1,18 @@
+import { fetchReportJson } from "../../../core/services/reportData.mts";
+
+type GlobalsData = import("../../../types/report.mts").GlobalsData;
+
+let globalsDataPromise: Promise<GlobalsData> | undefined;
+
+export const loadGlobalsData = (): Promise<GlobalsData> => {
+  if (!globalsDataPromise) {
+    globalsDataPromise = fetchReportJson<GlobalsData>("widgets/globals.json").catch(
+      (error: unknown) => {
+        globalsDataPromise = undefined;
+        throw error;
+      },
+    );
+  }
+
+  return globalsDataPromise;
+};

--- a/allure-generator/src/main/javascript/features/run/views/RunStatusBannerView.mts
+++ b/allure-generator/src/main/javascript/features/run/views/RunStatusBannerView.mts
@@ -1,0 +1,83 @@
+import "./RunStatusBannerView.scss";
+import { defineMountableElement } from "../../../core/view/elementView.mts";
+import translate from "../../../helpers/t.mts";
+import { createElement } from "../../../shared/dom.mts";
+import { createIconElement } from "../../../shared/icon/index.mts";
+
+type GlobalsData = import("../../../types/report.mts").GlobalsData;
+type SummaryData = import("../../../types/report.mts").SummaryData;
+
+type RunStatusBannerOptions = {
+  globals: GlobalsData;
+  summary: SummaryData;
+};
+
+const RunStatusBannerView = ({ globals, summary }: RunStatusBannerOptions) => {
+  const el = defineMountableElement(document.createElement("section"), {});
+
+  Object.assign(el, {
+    render() {
+      const errorCount = globals.errors.length;
+      const total = summary.statistic?.total || 0;
+      const passed = summary.statistic?.passed || 0;
+      const firstError = globals.errors[0];
+      const remainingErrors = Math.max(0, errorCount - 1);
+      const description =
+        total > 0 && passed === total
+          ? translate("run.allTestsPassedWithErrors", {
+              hash: { count: errorCount, tests: total },
+            })
+          : translate("run.errorsOutsideTests", { hash: { count: errorCount } });
+
+      el.className = "run-status-banner island";
+      el.setAttribute("role", "alert");
+      el.replaceChildren(
+        createElement("div", {
+          className: "run-status-banner__icon",
+          children: createIconElement("solidAlertCircle", { size: "l" }),
+        }),
+        createElement("div", {
+          className: "run-status-banner__body",
+          children: [
+            createElement("h2", {
+              className: "run-status-banner__title",
+              text: translate(total === 0 ? "run.failedBeforeTests" : "run.completedWithErrors"),
+            }),
+            createElement("p", {
+              className: "run-status-banner__description",
+              text: description,
+            }),
+            firstError?.message
+              ? createElement("p", {
+                  className: "run-status-banner__first-error",
+                  children: [
+                    firstError.message,
+                    remainingErrors
+                      ? ` ${translate("run.moreErrors", { hash: { count: remainingErrors } })}`
+                      : null,
+                  ],
+                })
+              : null,
+          ],
+        }),
+        createElement("a", {
+          attrs: {
+            "data-ga4-event": "run_details_click",
+            href: "#run",
+          },
+          className: "run-status-banner__link link",
+          children: [
+            translate("run.reviewDetails"),
+            createIconElement("lineArrowsChevronRight", { inline: true, size: "s" }),
+          ],
+        }),
+      );
+
+      return el;
+    },
+  });
+
+  return el;
+};
+
+export default RunStatusBannerView;

--- a/allure-generator/src/main/javascript/features/run/views/RunStatusBannerView.scss
+++ b/allure-generator/src/main/javascript/features/run/views/RunStatusBannerView.scss
@@ -1,0 +1,64 @@
+@use "../../../theme/spacing.scss" as *;
+
+.run-status-banner {
+  align-items: flex-start;
+  background: var(--color-intent-danger-bg-subtle);
+  border-color: var(--color-intent-danger-border);
+  box-shadow: none;
+  display: flex;
+  gap: gap(2);
+  padding: gap(2.5) gap(3);
+
+  &__icon {
+    color: var(--color-intent-danger-text);
+    flex: 0 0 auto;
+    padding-top: gap(0.25);
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  &__title {
+    color: var(--color-intent-danger-text);
+    font-size: var(--font-size-l);
+    font-weight: var(--font-weight-extra-bold);
+    line-height: var(--line-height-l);
+    margin: 0;
+  }
+
+  &__description,
+  &__first-error {
+    line-height: var(--line-height-m);
+    margin: gap(0.5) 0 0;
+  }
+
+  &__description {
+    color: var(--color-text-primary);
+  }
+
+  &__first-error {
+    color: var(--color-text-secondary);
+    overflow-wrap: anywhere;
+  }
+
+  &__link {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-weight: var(--font-weight-bold);
+    gap: gap(0.5);
+    margin-top: gap(0.25);
+  }
+}
+
+@media (max-width: $breakpoint-medium) {
+  .run-status-banner {
+    flex-wrap: wrap;
+
+    &__link {
+      margin-inline-start: gap(5);
+    }
+  }
+}

--- a/allure-generator/src/main/javascript/features/run/views/RunView.mts
+++ b/allure-generator/src/main/javascript/features/run/views/RunView.mts
@@ -21,9 +21,32 @@ type RunViewOptions = {
 
 const attachmentUid = (attachment: GlobalAttachment) => String(attachment.uid || attachment.source);
 
+const formatTimestamp = (timestamp: number | undefined) =>
+  typeof timestamp === "number"
+    ? translate("testResult.history.time", {
+        hash: { date: date(timestamp), time: time(timestamp, true) },
+      })
+    : undefined;
+
+const compareGlobalAttachments = (left: GlobalAttachment, right: GlobalAttachment) => {
+  const leftTimestamp = left.timestamp;
+  const rightTimestamp = right.timestamp;
+  const leftHasTimestamp = typeof leftTimestamp === "number";
+  const rightHasTimestamp = typeof rightTimestamp === "number";
+
+  if (leftHasTimestamp && rightHasTimestamp && leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+  if (leftHasTimestamp !== rightHasTimestamp) {
+    return leftHasTimestamp ? -1 : 1;
+  }
+
+  return String(left.name || left.source).localeCompare(String(right.name || right.source));
+};
+
 const createErrorCard = (error: GlobalError, index: number) => {
   const hasComparison = typeof error.actual === "string" || typeof error.expected === "string";
-  const hasTimestamp = typeof error.timestamp === "number";
+  const timestamp = formatTimestamp(error.timestamp);
 
   return createElement("article", {
     className: "run-view__error island",
@@ -41,12 +64,10 @@ const createErrorCard = (error: GlobalError, index: number) => {
           }),
         ],
       }),
-      hasTimestamp
+      timestamp
         ? createElement("div", {
             className: "run-view__timestamp",
-            text: translate("testResult.history.time", {
-              hash: { date: date(error.timestamp), time: time(error.timestamp, true) },
-            }),
+            text: timestamp,
           })
         : null,
       hasComparison
@@ -183,7 +204,7 @@ class RunViewElement extends BaseElement {
   }
 
   createAttachmentsSection() {
-    const attachments = this.data.attachments;
+    const attachments = [...this.data.attachments].sort(compareGlobalAttachments);
     return createElement("section", {
       className: "run-view__section",
       children: [
@@ -204,7 +225,9 @@ class RunViewElement extends BaseElement {
                 const normalized = { ...attachment, uid: attachmentUid(attachment) };
                 return createElement("div", {
                   className: "run-view__attachment",
-                  children: createAttachmentRow(normalized),
+                  children: createAttachmentRow(normalized, {
+                    details: formatTimestamp(attachment.timestamp),
+                  }),
                 });
               }),
             })

--- a/allure-generator/src/main/javascript/features/run/views/RunView.mts
+++ b/allure-generator/src/main/javascript/features/run/views/RunView.mts
@@ -1,0 +1,312 @@
+import "./RunView.scss";
+import BaseElement from "../../../core/elements/BaseElement.mts";
+import date from "../../../helpers/date.mts";
+import translate from "../../../helpers/t.mts";
+import time from "../../../helpers/time.mts";
+import { escapeHtml } from "../../../shared/html.mts";
+import { createElement } from "../../../shared/dom.mts";
+import { createIconElement } from "../../../shared/icon/index.mts";
+import ModalView from "../../../shared/ui/ModalView.mts";
+import TooltipView from "../../../shared/ui/TooltipView.mts";
+import { AttachmentView } from "../../attachments/runtime.mts";
+import { createAttachmentRow } from "../../attachments/views/renderAttachmentRow.mts";
+
+type GlobalAttachment = import("../../../types/report.mts").GlobalAttachment;
+type GlobalError = import("../../../types/report.mts").GlobalError;
+type GlobalsData = import("../../../types/report.mts").GlobalsData;
+
+type RunViewOptions = {
+  data: GlobalsData;
+};
+
+const attachmentUid = (attachment: GlobalAttachment) => String(attachment.uid || attachment.source);
+
+const createErrorCard = (error: GlobalError, index: number) => {
+  const hasComparison = typeof error.actual === "string" || typeof error.expected === "string";
+  const hasTimestamp = typeof error.timestamp === "number";
+
+  return createElement("article", {
+    className: "run-view__error island",
+    children: [
+      createElement("div", {
+        className: "run-view__error-head",
+        children: [
+          createElement("div", {
+            className: "run-view__error-index",
+            text: index + 1,
+          }),
+          createElement("h3", {
+            className: "run-view__error-message",
+            text: error.message || translate("run.unknownError"),
+          }),
+        ],
+      }),
+      hasTimestamp
+        ? createElement("div", {
+            className: "run-view__timestamp",
+            text: translate("testResult.history.time", {
+              hash: { date: date(error.timestamp), time: time(error.timestamp, true) },
+            }),
+          })
+        : null,
+      hasComparison
+        ? createElement("dl", {
+            className: "run-view__comparison",
+            children: [
+              typeof error.expected === "string"
+                ? [
+                    createElement("dt", { text: translate("run.expected") }),
+                    createElement("dd", { text: error.expected }),
+                  ]
+                : null,
+              typeof error.actual === "string"
+                ? [
+                    createElement("dt", { text: translate("run.actual") }),
+                    createElement("dd", { text: error.actual }),
+                  ]
+                : null,
+            ],
+          })
+        : null,
+      error.trace
+        ? createElement("details", {
+            className: "run-view__trace",
+            children: [
+              createElement("summary", { text: translate("run.trace") }),
+              createElement("pre", {
+                children: createElement("code", { text: error.trace }),
+              }),
+            ],
+          })
+        : null,
+    ],
+  });
+};
+
+class RunViewElement extends BaseElement {
+  declare options: RunViewOptions;
+
+  declare data: GlobalsData;
+
+  declare tooltip: TooltipView;
+
+  declare modalView: ReturnType<typeof ModalView> | null;
+
+  constructor() {
+    super();
+    this.data = { errors: [], attachments: [] };
+    this.tooltip = new TooltipView({ position: "left" });
+    this.modalView = null;
+  }
+
+  setOptions(options: RunViewOptions) {
+    super.setOptions(options);
+    this.data = options.data;
+    return this;
+  }
+
+  renderElement() {
+    const errorCount = this.data.errors.length;
+    const failed = errorCount > 0;
+
+    this.className = "run-view";
+    this.replaceChildren(
+      createElement("h1", {
+        className: "pane__title",
+        text: translate("tab.run.name"),
+      }),
+      createElement("div", {
+        className: `run-view__outcome island run-view__outcome_${failed ? "failed" : "clean"}`,
+        children: [
+          createElement("div", {
+            className: "run-view__outcome-icon",
+            children: createIconElement(failed ? "solidAlertCircle" : "lineGeneralInfoCircle", {
+              size: "l",
+            }),
+          }),
+          createElement("div", {
+            children: [
+              createElement("h2", {
+                className: "run-view__outcome-title",
+                text: translate(failed ? "run.failed" : "run.noErrors"),
+              }),
+              createElement("p", {
+                className: "run-view__outcome-description",
+                text: translate(failed ? "run.failureExplanation" : "run.noErrorsExplanation"),
+              }),
+            ],
+          }),
+        ],
+      }),
+      this.createErrorsSection(),
+      this.createAttachmentsSection(),
+    );
+    this.bindEvents(
+      {
+        "click .attachment-row__fullscreen": "onAttachmentFullscreenClick",
+        "click .attachment-row": "onAttachmentClick",
+        "mouseenter [data-tooltip]": "onTooltipHover",
+        "mouseleave [data-tooltip]": "onTooltipLeave",
+      },
+      this,
+    );
+
+    return this;
+  }
+
+  createErrorsSection() {
+    const errors = this.data.errors;
+    return createElement("section", {
+      className: "run-view__section",
+      children: [
+        createElement("h2", {
+          className: "run-view__section-title",
+          children: [
+            translate("run.errors"),
+            createElement("span", {
+              className: "run-view__count",
+              text: errors.length,
+            }),
+          ],
+        }),
+        errors.length
+          ? createElement("div", {
+              className: "run-view__errors",
+              children: errors.map(createErrorCard),
+            })
+          : createElement("p", {
+              className: "run-view__empty",
+              text: translate("run.noErrors"),
+            }),
+      ],
+    });
+  }
+
+  createAttachmentsSection() {
+    const attachments = this.data.attachments;
+    return createElement("section", {
+      className: "run-view__section",
+      children: [
+        createElement("h2", {
+          className: "run-view__section-title",
+          children: [
+            translate("run.attachments"),
+            createElement("span", {
+              className: "run-view__count",
+              text: attachments.length,
+            }),
+          ],
+        }),
+        attachments.length
+          ? createElement("div", {
+              className: "run-view__attachments island",
+              children: attachments.map((attachment) => {
+                const normalized = { ...attachment, uid: attachmentUid(attachment) };
+                return createElement("div", {
+                  className: "run-view__attachment",
+                  children: createAttachmentRow(normalized),
+                });
+              }),
+            })
+          : createElement("p", {
+              className: "run-view__empty",
+              text: translate("run.noAttachments"),
+            }),
+      ],
+    });
+  }
+
+  findAttachment(uid: string) {
+    return this.data.attachments.find((attachment) => attachmentUid(attachment) === uid);
+  }
+
+  onAttachmentClick(event: Event) {
+    const row = event.currentTarget as HTMLElement;
+    const target = event.target;
+    if (
+      target instanceof Element &&
+      target.closest("[data-download], .attachment-row__fullscreen")
+    ) {
+      return;
+    }
+
+    const uid = row.dataset.uid;
+    if (!uid) {
+      return;
+    }
+    const attachment = this.findAttachment(uid);
+    if (!attachment) {
+      return;
+    }
+    if (row.dataset.viewer === "playwright-trace") {
+      this.showAttachmentModal(attachment);
+      return;
+    }
+
+    const name = `attachment__${uid}`;
+    if (row.classList.contains("attachment-row_selected") && this.getMountedChild(name)) {
+      this.unmountChild(name);
+    } else {
+      this.mountChild(
+        name,
+        AttachmentView({ attachment: { ...attachment, uid } }),
+        this.querySelector(`.${name}`),
+      );
+    }
+    row.classList.toggle("attachment-row_selected");
+  }
+
+  onAttachmentFullscreenClick(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const uid = (event.currentTarget as Element)
+      .closest(".attachment-row")
+      ?.getAttribute("data-uid");
+    const attachment = uid ? this.findAttachment(uid) : undefined;
+    if (attachment) {
+      this.showAttachmentModal(attachment);
+    }
+  }
+
+  showAttachmentModal(attachment: GlobalAttachment) {
+    this.modalView?.destroy();
+    const childView = AttachmentView({
+      attachment: { ...attachment, uid: attachmentUid(attachment) },
+      fullScreen: true,
+    });
+    childView.suppressRouteReset = true;
+    this.modalView = ModalView({
+      childView,
+      title: attachment.name || attachment.source,
+    });
+    this.modalView.show();
+  }
+
+  onTooltipHover(event: Event) {
+    const element = event.currentTarget as HTMLElement;
+    this.tooltip.show(escapeHtml(element.dataset.tooltip || ""), element);
+  }
+
+  onTooltipLeave() {
+    this.tooltip.hide();
+  }
+
+  destroy() {
+    this.tooltip.hide();
+    this.modalView?.destroy();
+    this.modalView = null;
+    super.destroy();
+  }
+}
+
+if (!customElements.get("allure-run-view")) {
+  customElements.define("allure-run-view", RunViewElement);
+}
+
+const RunView = (options: RunViewOptions) => {
+  const element = document.createElement("allure-run-view") as RunViewElement;
+  element.setOptions(options);
+  return element;
+};
+
+export default RunView;

--- a/allure-generator/src/main/javascript/features/run/views/RunView.scss
+++ b/allure-generator/src/main/javascript/features/run/views/RunView.scss
@@ -1,0 +1,186 @@
+@use "../../../theme/spacing.scss" as *;
+
+.run-view {
+  box-sizing: border-box;
+  min-height: 100%;
+  padding-bottom: var(--layout-scroll-end-padding);
+
+  &__outcome,
+  &__section {
+    margin: gap(3);
+    max-width: 1096px;
+  }
+
+  &__outcome {
+    align-items: flex-start;
+    display: flex;
+    gap: gap(2);
+    padding: gap(2.5) gap(3);
+
+    &_failed {
+      background: var(--color-intent-danger-bg-subtle);
+      border-color: var(--color-intent-danger-border);
+
+      .run-view__outcome-icon,
+      .run-view__outcome-title {
+        color: var(--color-intent-danger-text);
+      }
+    }
+
+    &_clean .run-view__outcome-icon {
+      color: var(--color-intent-info-text);
+    }
+  }
+
+  &__outcome-icon {
+    flex: 0 0 auto;
+  }
+
+  &__outcome-title {
+    font-size: var(--font-size-l);
+    line-height: var(--line-height-l);
+    margin: 0;
+  }
+
+  &__outcome-description {
+    color: var(--color-text-secondary);
+    line-height: var(--line-height-m);
+    margin: gap(0.5) 0 0;
+  }
+
+  &__section-title {
+    align-items: center;
+    display: flex;
+    font-size: var(--font-size-l);
+    gap: gap(1);
+    line-height: var(--line-height-l);
+    margin: 0 0 gap(2);
+  }
+
+  &__count {
+    align-items: center;
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-pill);
+    color: var(--color-text-secondary);
+    display: inline-flex;
+    font-size: var(--font-size-s);
+    font-weight: var(--font-weight-bold);
+    justify-content: center;
+    min-width: gap(2.5);
+    padding: 0 gap(0.75);
+  }
+
+  &__errors {
+    display: grid;
+    gap: gap(2);
+  }
+
+  &__error {
+    box-shadow: none;
+    padding: gap(2.5);
+  }
+
+  &__error-head {
+    align-items: flex-start;
+    display: flex;
+    gap: gap(1);
+  }
+
+  &__error-index {
+    align-items: center;
+    background: var(--color-status-failed-bg);
+    border-radius: var(--radius-pill);
+    color: var(--color-status-failed-on-bg);
+    display: inline-flex;
+    flex: 0 0 gap(3);
+    font-size: var(--font-size-s);
+    font-weight: var(--font-weight-bold);
+    height: gap(3);
+    justify-content: center;
+  }
+
+  &__error-message {
+    flex: 1 1 auto;
+    font-size: var(--font-size-m);
+    line-height: var(--line-height-m);
+    margin: gap(0.25) 0 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__timestamp {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-s);
+    margin: gap(1) 0 0 gap(4);
+  }
+
+  &__comparison {
+    display: grid;
+    gap: gap(0.5) gap(2);
+    grid-template-columns: max-content minmax(0, 1fr);
+    margin: gap(2) 0 0 gap(4);
+
+    dt {
+      color: var(--color-text-secondary);
+      font-weight: var(--font-weight-bold);
+    }
+
+    dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__trace {
+    margin: gap(2) 0 0 gap(4);
+
+    summary {
+      color: var(--color-link-text);
+      cursor: pointer;
+      font-weight: var(--font-weight-bold);
+    }
+
+    pre {
+      background: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: var(--radius-1);
+      box-sizing: border-box;
+      max-height: 416px;
+      overflow: auto;
+      padding: gap(2);
+      white-space: pre-wrap;
+    }
+  }
+
+  &__attachments {
+    box-shadow: none;
+    padding: 0;
+  }
+
+  &__attachment + &__attachment {
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  &__empty {
+    color: var(--color-text-secondary);
+    margin: 0;
+  }
+}
+
+@media (max-width: $breakpoint-medium) {
+  .run-view {
+    &__outcome,
+    &__section {
+      margin: gap(2);
+    }
+
+    &__error-head {
+      flex-wrap: wrap;
+    }
+
+    &__timestamp,
+    &__comparison,
+    &__trace {
+      margin-inline-start: 0;
+    }
+  }
+}

--- a/allure-generator/src/main/javascript/features/shell/SideNavElement.mts
+++ b/allure-generator/src/main/javascript/features/shell/SideNavElement.mts
@@ -11,6 +11,7 @@ import { createIconElement } from "../../shared/icon/index.mts";
 import { THEME_CHANGE_EVENT, getActiveTheme, toggleTheme } from "../../shared/theme.mts";
 import TooltipView from "../../shared/ui/TooltipView.mts";
 import { findWhere } from "../../shared/utils/collections.mts";
+import { loadGlobalsData } from "../run/model/globalsData.mts";
 import LanguageSelectView from "./LanguageSelectView.mts";
 
 const getThemeSwitchLabel = () =>
@@ -26,11 +27,14 @@ class SideNavCustomElement extends BaseElement {
 
   declare onThemeChange: () => void;
 
+  declare runStatusRequestId: number;
+
   constructor() {
     super();
     this.tooltip = new TooltipView({ position: "right" });
     this.langSelect = new LanguageSelectView();
     this.onThemeChange = this.updateThemeSwitch.bind(this);
+    this.runStatusRequestId = 0;
   }
 
   renderElement() {
@@ -78,18 +82,30 @@ class SideNavCustomElement extends BaseElement {
               "data-ga4-event": "tab_click",
               "data-ga4-param-tab": tabName,
               "data-tooltip": translate(title),
+              ...(tabName === "run" ? { hidden: "" } : {}),
             },
             className: b("side-nav", "item"),
             children: createElement("a", {
-              attrs: { href: `#${tabName}` },
+              attrs: { "data-tab": tabName, href: `#${tabName}` },
               className: linkClass,
               children: [
                 createElement("span", {
                   className: b("side-nav", "icon-lane"),
-                  children: createIconElement(icon, {
-                    className: b("side-nav", "icon"),
-                    size: "m",
-                  }),
+                  children: [
+                    createIconElement(icon, {
+                      className: b("side-nav", "icon"),
+                      size: "m",
+                    }),
+                    tabName === "run"
+                      ? createElement("span", {
+                          attrs: {
+                            "aria-hidden": "true",
+                            hidden: "",
+                          },
+                          className: b("side-nav", "badge"),
+                        })
+                      : null,
+                  ],
                 }),
                 createElement("span", {
                   className: b("side-nav", "text"),
@@ -197,8 +213,43 @@ class SideNavCustomElement extends BaseElement {
       },
       this,
     );
+    this.loadRunStatus(++this.runStatusRequestId);
 
     return this;
+  }
+
+  loadRunStatus(requestId: number) {
+    loadGlobalsData()
+      .then(({ attachments, errors }) => {
+        if (requestId !== this.runStatusRequestId) {
+          return;
+        }
+        const link = this.querySelector<HTMLAnchorElement>('.side-nav__link[data-tab="run"]');
+        const badge = link?.querySelector<HTMLElement>(".side-nav__badge");
+        const item = link?.closest<HTMLElement>(".side-nav__item");
+        if (!link || !badge || !item) {
+          return;
+        }
+
+        if (errors.length === 0 && attachments.length === 0) {
+          item.remove();
+          return;
+        }
+
+        const errorCount = errors.length;
+        item.removeAttribute("hidden");
+        link.classList.toggle("side-nav__link_error", errorCount > 0);
+        badge.toggleAttribute("hidden", errorCount === 0);
+        badge.textContent = String(errorCount);
+        item.dataset.tooltip = errorCount
+          ? `${translate("tab.run.name")} · ${translate("run.errorCount", {
+              hash: { count: errorCount },
+            })}`
+          : translate("tab.run.name");
+      })
+      .catch(() => {
+        // Keep shell navigation usable; the page-level loader renders the data error.
+      });
   }
 
   isTabActive(name: string) {
@@ -312,6 +363,7 @@ class SideNavCustomElement extends BaseElement {
   }
 
   destroy() {
+    this.runStatusRequestId += 1;
     this.tooltip.hide();
     this.langSelect.hide();
     super.destroy();

--- a/allure-generator/src/main/javascript/features/shell/SideNavView.scss
+++ b/allure-generator/src/main/javascript/features/shell/SideNavView.scss
@@ -66,6 +66,10 @@ $side-nav-control-size: gap(4);
   &__item {
     display: block;
     font-size: var(--font-size-m);
+
+    &[hidden] {
+      display: none;
+    }
   }
 
   &__link,
@@ -121,6 +125,14 @@ $side-nav-control-size: gap(4);
       }
     }
 
+    &_error {
+      color: var(--color-status-failed-text);
+
+      .side-nav__icon {
+        color: var(--color-status-failed-text);
+      }
+    }
+
     &:focus-visible {
       outline: 2px solid var(--color-focus-ring);
       outline-offset: -2px;
@@ -134,6 +146,30 @@ $side-nav-control-size: gap(4);
     inline-size: $side-nav-icon-lane-width;
     justify-content: center;
     min-inline-size: $side-nav-icon-lane-width;
+    position: relative;
+  }
+
+  &__badge {
+    align-items: center;
+    background: var(--color-status-failed-bg);
+    border: 1px solid var(--color-bg-secondary);
+    border-radius: var(--radius-pill);
+    color: var(--color-status-failed-on-bg);
+    display: inline-flex;
+    font-size: 9px;
+    font-weight: var(--font-weight-bold);
+    height: gap(2);
+    justify-content: center;
+    line-height: 1;
+    min-width: gap(2);
+    padding: 0 gap(0.25);
+    position: absolute;
+    right: gap(0.75);
+    top: gap(0.5);
+
+    &[hidden] {
+      display: none;
+    }
   }
 
   &__icon {

--- a/allure-generator/src/main/javascript/features/test-result/views/renderTestResultExecution.mts
+++ b/allure-generator/src/main/javascript/features/test-result/views/renderTestResultExecution.mts
@@ -1,18 +1,14 @@
 import { createAllureIconElement } from "../../../helpers/allure-icon.mts";
 import dateHelper from "../../../helpers/date.mts";
 import duration from "../../../helpers/duration.mts";
-import fileicon from "../../../helpers/fileicon.mts";
-import filesize from "../../../helpers/filesize.mts";
 import translate from "../../../helpers/t.mts";
 import { createTextWithLinksFragment } from "../../../helpers/text-with-links.mts";
 import timeHelper from "../../../helpers/time.mts";
 import b from "../../../shared/bem/index.mts";
 import { createElement, createFragment } from "../../../shared/dom.mts";
 import { createIconElement } from "../../../shared/icon/index.mts";
-import { AttachmentPreviewView } from "../../attachments/model/attachmentPreviewView.mts";
-import attachmentType from "../../attachments/model/attachmentType.mts";
+import { createAttachmentRow } from "../../attachments/views/renderAttachmentRow.mts";
 import { createStatusDetailsElement } from "./renderStatusDetails.mts";
-type Attachment = import("../../../types/report.mts").Attachment;
 type Parameter = import("../../../types/report.mts").Parameter;
 type Stage = import("../../../types/report.mts").Stage;
 type Step = import("../../../types/report.mts").Step;
@@ -89,85 +85,6 @@ const createStepStats = ({
     }),
   };
 };
-
-const createAttachmentRow = ({ uid, type, name, source, size }: Attachment) =>
-  (() => {
-    const attachmentInfo = attachmentType(type || "");
-    const isTraceAttachment = attachmentInfo.view === AttachmentPreviewView.PlaywrightTrace;
-
-    return createElement("div", {
-      children: [
-        createElement("div", {
-          attrs: {
-            "data-type": type,
-            "data-uid": uid,
-            ...(isTraceAttachment ? { "data-viewer": "playwright-trace" } : {}),
-          },
-          className: "attachment-row",
-          children: [
-            createElement("span", {
-              className: "attachment-row__arrow block__arrow",
-              children: createIconElement(
-                isTraceAttachment ? "lineGeneralLinkExternal" : "lineArrowsChevronRight",
-                {
-                  className: "angle",
-                  size: "s",
-                },
-              ),
-            }),
-            createElement("div", {
-              attrs: type ? { "data-tooltip": type } : {},
-              className: "attachment-row__icon",
-              children: createIconElement(fileicon(type), {
-                size: "s",
-                title: type || "",
-              }),
-            }),
-            createElement("div", {
-              className: "attachment-row__name long-line",
-              text: name || source,
-            }),
-            createElement("div", {
-              className: "attachment-row__control attachment-row__link",
-              children: createElement("div", {
-                attrs: {
-                  "data-download": `data/attachments/${source}`,
-                  "data-download-target": "_blank",
-                  "data-download-type": type,
-                  "data-tooltip": translate("testResult.execution.downloadAttachment.tooltip"),
-                },
-                className: "link",
-                children: [
-                  createIconElement("lineGeneralDownloadCloud", {
-                    inline: true,
-                    size: "s",
-                  }),
-                  " ",
-                  filesize(size),
-                ],
-              }),
-            }),
-            createElement("div", {
-              className: "attachment-row__control attachment-row__fullscreen",
-              children: createElement("a", {
-                className: "link",
-                children: createIconElement("lineLayoutsMaximize2", {
-                  inline: true,
-                  size: "s",
-                }),
-              }),
-            }),
-          ],
-        }),
-        createElement("div", {
-          className: "attachment-row__preview",
-          children: createElement("div", {
-            className: `attachment-row__content ${b("attachment", String(uid))}`,
-          }),
-        }),
-      ],
-    });
-  })();
 
 const createStepTitle = ({
   hasContent,

--- a/allure-generator/src/main/javascript/shared/styles/primitives/attachment-row/styles.scss
+++ b/allure-generator/src/main/javascript/shared/styles/primitives/attachment-row/styles.scss
@@ -35,9 +35,14 @@
     width: gap(2);
     height: gap(2);
   }
-  &__name {
+  &__label {
     flex: 1 1 auto;
     min-width: 0;
+  }
+  &__details {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-s);
+    margin-block-start: gap(0.25);
   }
   &__control {
     padding-inline-start: gap(2);

--- a/allure-generator/src/main/javascript/translations/am.json
+++ b/allure-generator/src/main/javascript/translations/am.json
@@ -104,6 +104,26 @@
     "newPassed": "Նոր հաջողված",
     "retriesStatusChange": "Կարգավիճակը փոխվեց կրկնելուց հետո"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "տևողություն",
     "name": "անուն",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Փաթեթներ"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Թեստի փաթեթներ"

--- a/allure-generator/src/main/javascript/translations/az.json
+++ b/allure-generator/src/main/javascript/translations/az.json
@@ -104,6 +104,26 @@
     "newPassed": "Yeni keçmiş",
     "retriesStatusChange": "Yenidən cəhd etdikdən sonra status dəyişib"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "müddət",
     "name": "ad",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Paketlər"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Test dəsti"

--- a/allure-generator/src/main/javascript/translations/br.json
+++ b/allure-generator/src/main/javascript/translations/br.json
@@ -110,6 +110,26 @@
     "newPassed": "Novo passou",
     "retriesStatusChange": "Status alterado após nova tentativa"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "duração",
     "name": "nome",
@@ -138,6 +158,9 @@
     },
     "packages": {
       "name": "Pacotes"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suítes"

--- a/allure-generator/src/main/javascript/translations/de.json
+++ b/allure-generator/src/main/javascript/translations/de.json
@@ -104,6 +104,26 @@
     "newPassed": "Neu erfolgreich",
     "retriesStatusChange": "Status nach erneutem Versuch geändert"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "Dauer",
     "name": "Name",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Pakete"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suiten"

--- a/allure-generator/src/main/javascript/translations/en.json
+++ b/allure-generator/src/main/javascript/translations/en.json
@@ -104,6 +104,26 @@
     "newPassed": "New passed",
     "retriesStatusChange": "Status changed after retry"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "duration",
     "name": "name",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Packages"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suites"

--- a/allure-generator/src/main/javascript/translations/es.json
+++ b/allure-generator/src/main/javascript/translations/es.json
@@ -106,6 +106,26 @@
     "newPassed": "Nuevo pasado",
     "retriesStatusChange": "El estado cambió después de reintentar"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "duración",
     "name": "nombre",
@@ -134,6 +154,9 @@
     },
     "packages": {
       "name": "Paquetes"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suites de prueba"

--- a/allure-generator/src/main/javascript/translations/fr.json
+++ b/allure-generator/src/main/javascript/translations/fr.json
@@ -106,6 +106,26 @@
     "newPassed": "Réussi (nouveau)",
     "retriesStatusChange": "L'état a changé après une nouvelle tentative"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "durée",
     "name": "nom",
@@ -134,6 +154,9 @@
     },
     "packages": {
       "name": "Paquets"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suites de tests"

--- a/allure-generator/src/main/javascript/translations/he.json
+++ b/allure-generator/src/main/javascript/translations/he.json
@@ -106,6 +106,26 @@
     "newPassed": "חדש עבר",
     "retriesStatusChange": "הסטטוס השתנה לאחר ניסיון חוזר"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "זמן ריצה",
     "name": "שם מקרה הבדיקה",
@@ -134,6 +154,9 @@
     },
     "packages": {
       "name": "חבילות"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "קבוצות מקרי בדיקה"

--- a/allure-generator/src/main/javascript/translations/hu.json
+++ b/allure-generator/src/main/javascript/translations/hu.json
@@ -104,6 +104,26 @@
     "newPassed": "Új sikeres",
     "retriesStatusChange": "Státusz változott ismétlés után"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "futásidő",
     "name": "név",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Modulok"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Tesztek"

--- a/allure-generator/src/main/javascript/translations/isv.json
+++ b/allure-generator/src/main/javascript/translations/isv.json
@@ -112,6 +112,26 @@
     "newPassed": "Iznova uspěšny",
     "retriesStatusChange": "Status měnjal se od proby do proby"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "trvanje",
     "name": "nazva",
@@ -140,6 +160,9 @@
     },
     "packages": {
       "name": "Pakety"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Komplety testov"

--- a/allure-generator/src/main/javascript/translations/it.json
+++ b/allure-generator/src/main/javascript/translations/it.json
@@ -106,6 +106,26 @@
     "newPassed": "Nuovo passato",
     "retriesStatusChange": "Stato cambiato dopo un tentativo"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "durata",
     "name": "nome",
@@ -134,6 +154,9 @@
     },
     "packages": {
       "name": "Pacchetti"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Suite"

--- a/allure-generator/src/main/javascript/translations/ja.json
+++ b/allure-generator/src/main/javascript/translations/ja.json
@@ -104,6 +104,26 @@
     "newPassed": "新しい成功",
     "retriesStatusChange": "再試行後にステータスが変更されました"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "期間",
     "name": "名前",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "パッケージ"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "スイート"

--- a/allure-generator/src/main/javascript/translations/ka.json
+++ b/allure-generator/src/main/javascript/translations/ka.json
@@ -104,6 +104,26 @@
     "newPassed": "ახალი წარმატებული",
     "retriesStatusChange": "სტატუსი შეიცვალა ხელახლა მცდელობისას"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "ხანგრძლივობა",
     "name": "სათაური",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "პაკეტები"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "პაკეტები"

--- a/allure-generator/src/main/javascript/translations/kr.json
+++ b/allure-generator/src/main/javascript/translations/kr.json
@@ -104,6 +104,26 @@
     "newPassed": "새로운 통과",
     "retriesStatusChange": "새재시도 후 상태가 변경됨"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "소요시간",
     "name": "이름",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "패키지"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "스위트"

--- a/allure-generator/src/main/javascript/translations/nl.json
+++ b/allure-generator/src/main/javascript/translations/nl.json
@@ -104,6 +104,26 @@
     "newPassed": "Nieuw geslaagd",
     "retriesStatusChange": "Status gewijzigd na opnieuw proberen"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "duur",
     "name": "naam",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Pakketten"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Testreeksen"

--- a/allure-generator/src/main/javascript/translations/pl.json
+++ b/allure-generator/src/main/javascript/translations/pl.json
@@ -112,6 +112,26 @@
     "newPassed": "Nowy udany",
     "retriesStatusChange": "Status zmieniony po ponownej próbie"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "czas trwania",
     "name": "nazwa",
@@ -140,6 +160,9 @@
     },
     "packages": {
       "name": "Pakiety"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Zestawy"

--- a/allure-generator/src/main/javascript/translations/ru.json
+++ b/allure-generator/src/main/javascript/translations/ru.json
@@ -112,6 +112,26 @@
     "newPassed": "Новый пройденный",
     "retriesStatusChange": "Изменение статуса в перезапуске"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "длительность",
     "name": "имя",
@@ -140,6 +160,9 @@
     },
     "packages": {
       "name": "Пакеты"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Тест сюиты"

--- a/allure-generator/src/main/javascript/translations/sv.json
+++ b/allure-generator/src/main/javascript/translations/sv.json
@@ -104,6 +104,26 @@
     "newPassed": "Ny godkänd",
     "retriesStatusChange": "Status ändrades efter ett nytt försök"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "varaktighet",
     "name": "namn",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Paket"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Testsviter"

--- a/allure-generator/src/main/javascript/translations/tr.json
+++ b/allure-generator/src/main/javascript/translations/tr.json
@@ -104,6 +104,26 @@
     "newPassed": "Yeni Başarılı",
     "retriesStatusChange": "Yeniden deneme sonrası durum değişikliği"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "süre",
     "name": "ad",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "Paketler"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "Test Suitleri"

--- a/allure-generator/src/main/javascript/translations/zh.json
+++ b/allure-generator/src/main/javascript/translations/zh.json
@@ -104,6 +104,26 @@
     "newPassed": "新的通过",
     "retriesStatusChange": "重试后状态改变"
   },
+  "run": {
+    "actual": "Actual",
+    "allTestsPassedWithErrors": "All {{tests}} reported tests passed, but this run is unsuccessful. Run errors: {{count}}.",
+    "attachments": "Attachments",
+    "completedWithErrors": "Run completed with errors",
+    "errorCount": "Run errors: {{count}}",
+    "errors": "Errors",
+    "errorsOutsideTests": "Run-level errors outside test results: {{count}}.",
+    "expected": "Expected",
+    "failed": "Run failed",
+    "failedBeforeTests": "Run failed before tests were reported",
+    "failureExplanation": "These errors happened outside test results. Test statistics remain unchanged.",
+    "moreErrors": "and {{count}} additional errors",
+    "noAttachments": "No run-level attachments were reported.",
+    "noErrors": "No run errors",
+    "noErrorsExplanation": "No errors outside test results were reported for this run.",
+    "reviewDetails": "Review run details",
+    "trace": "Trace",
+    "unknownError": "Unknown run error"
+  },
   "sorter": {
     "duration": "用时",
     "name": "名称",
@@ -132,6 +152,9 @@
     },
     "packages": {
       "name": "包"
+    },
+    "run": {
+      "name": "Run"
     },
     "suites": {
       "name": "测试套件"

--- a/allure-generator/src/main/javascript/types/report.mts
+++ b/allure-generator/src/main/javascript/types/report.mts
@@ -31,6 +31,28 @@ export type Attachment = {
   size?: number;
 };
 
+export type GlobalError = {
+  timestamp?: number;
+  message?: string;
+  trace?: string;
+  actual?: string;
+  expected?: string;
+};
+
+export type GlobalAttachment = Attachment;
+
+export type GlobalsData = {
+  errors: GlobalError[];
+  attachments: GlobalAttachment[];
+};
+
+export type SummaryData = {
+  reportName?: string;
+  testRuns?: unknown[];
+  statistic?: Statistic;
+  time?: Time;
+};
+
 export type Step = {
   name?: string;
   description?: string;

--- a/allure-generator/src/main/javascript/types/report.mts
+++ b/allure-generator/src/main/javascript/types/report.mts
@@ -39,7 +39,9 @@ export type GlobalError = {
   expected?: string;
 };
 
-export type GlobalAttachment = Attachment;
+export type GlobalAttachment = Attachment & {
+  timestamp?: number;
+};
 
 export type GlobalsData = {
   errors: GlobalError[];

--- a/allure-generator/src/test/java/io/qameta/allure/DefaultResultsVisitorTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/DefaultResultsVisitorTest.java
@@ -16,7 +16,10 @@
 package io.qameta.allure;
 
 import io.qameta.allure.core.Configuration;
+import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.Parameter;
 import io.qameta.allure.entity.TestResult;
 import org.junit.jupiter.api.Test;
@@ -139,5 +142,29 @@ class DefaultResultsVisitorTest {
         assertThat(attachment.getType()).isEqualTo(DefaultResultsVisitor.APPLICATION_OCTET_STREAM);
         assertThat(attachment.getSource()).endsWith(".foobar");
         assertThat(attachment.getSize()).isEqualTo(14L);
+    }
+
+    /**
+     * Verifies preserving run-level data independently from test results.
+     */
+    @Description
+    @Test
+    void shouldStoreGlobalErrorsAndAttachments() {
+        final DefaultResultsVisitor visitor = new DefaultResultsVisitor(ConfigurationBuilder.empty().build());
+        final GlobalError error = new GlobalError().setMessage("Run setup failed");
+        final GlobalAttachment attachment = new GlobalAttachment()
+                .setUid("attachment-uid")
+                .setName("Run log")
+                .setSource("attachment-uid.txt")
+                .setType("text/plain")
+                .setSize(12L);
+
+        visitor.visitGlobalError(error);
+        visitor.visitGlobalAttachment(attachment);
+
+        final LaunchResults launch = visitor.getLaunchResults();
+        assertThat(launch.getResults()).isEmpty();
+        assertThat(launch.getGlobalErrors()).containsExactly(error);
+        assertThat(launch.getGlobalAttachments()).containsExactly(attachment);
     }
 }

--- a/allure-generator/src/test/java/io/qameta/allure/ReportGeneratorTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/ReportGeneratorTest.java
@@ -246,6 +246,16 @@ class ReportGeneratorTest {
     }
 
     /**
+     * Verifies generating run-level data even when the input format has no globals.
+     */
+    @Description
+    @Test
+    void shouldGenerateWidgetGlobalsJson() {
+        assertThat(output.resolve("widgets/globals.json"))
+                .isRegularFile();
+    }
+
+    /**
      * Verifies generating attachments for report generation.
      */
     @Description

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -591,7 +591,7 @@ class Allure2PluginTest {
                                 1724662800000L,
                                 "Container DatabaseTests failed, tests inside it did not run",
                                 "java.lang.IllegalStateException: database is unavailable\n"
-                                + "\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
+                                        + "\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
                                 "database unavailable",
                                 "database ready"
                         )

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -22,6 +22,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.core.Configuration;
 import io.qameta.allure.core.LaunchResults;
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.LabelName;
 import io.qameta.allure.entity.Parameter;
 import io.qameta.allure.entity.StageResult;
@@ -563,6 +564,68 @@ class Allure2PluginTest {
                 );
 
         assertThat(attachments.get(0).getSource()).endsWith(".txt");
+    }
+
+    /**
+     * Verifies reading run-level errors and attachments without creating a phantom test result.
+     */
+    @Description
+    @Test
+    void shouldReadGlobalErrorsAndAttachmentsWithoutTestResults() throws IOException {
+        final LaunchResults results = process(
+                "allure2/globals.json", UUID.randomUUID() + "-globals.json",
+                "allure2/launch.log", "launch.log"
+        );
+
+        assertThat(results.getResults()).isEmpty();
+        assertThat(results.getGlobalErrors())
+                .extracting(
+                        GlobalError::getTimestamp,
+                        GlobalError::getMessage,
+                        GlobalError::getTrace,
+                        GlobalError::getActual,
+                        GlobalError::getExpected
+                )
+                .containsExactly(
+                        tuple(
+                                1724662800000L,
+                                "Container DatabaseTests failed, tests inside it did not run",
+                                "java.lang.IllegalStateException: database is unavailable\n"
+                                + "\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
+                                "database unavailable",
+                                "database ready"
+                        )
+                );
+        assertThat(results.getGlobalAttachments())
+                .singleElement()
+                .satisfies(attachment -> {
+                    assertThat(attachment.getName()).isEqualTo("Launch log");
+                    assertThat(attachment.getType()).isEqualTo("text/plain");
+                    assertThat(attachment.getSource()).endsWith(".txt");
+                    assertThat(attachment.getSize()).isPositive();
+                });
+        assertThat(results.getAttachments())
+                .hasSize(1)
+                .allSatisfy((path, attachment) -> {
+                    assertThat(path.getFileName()).hasToString("launch.log");
+                    assertThat(attachment.getSource()).endsWith(".txt");
+                });
+    }
+
+    /**
+     * Verifies omitting global attachment metadata when its content is missing.
+     */
+    @Description
+    @Test
+    void shouldOmitGlobalAttachmentWhenContentIsMissing() throws IOException {
+        final LaunchResults results = process(
+                "allure2/globals.json", UUID.randomUUID() + "-globals.json"
+        );
+
+        assertThat(results.getResults()).isEmpty();
+        assertThat(results.getGlobalErrors()).hasSize(1);
+        assertThat(results.getGlobalAttachments()).isEmpty();
+        assertThat(results.getAttachments()).isEmpty();
     }
 
     /**

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -599,6 +599,7 @@ class Allure2PluginTest {
         assertThat(results.getGlobalAttachments())
                 .singleElement()
                 .satisfies(attachment -> {
+                    assertThat(attachment.getTimestamp()).isEqualTo(1724662800500L);
                     assertThat(attachment.getName()).isEqualTo("Launch log");
                     assertThat(attachment.getType()).isEqualTo("text/plain");
                     assertThat(attachment.getSource()).endsWith(".txt");

--- a/allure-generator/src/test/java/io/qameta/allure/globals/GlobalsPluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/globals/GlobalsPluginTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.globals;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.ConfigurationBuilder;
+import io.qameta.allure.DefaultLaunchResults;
+import io.qameta.allure.Description;
+import io.qameta.allure.ReportStorage;
+import io.qameta.allure.core.Configuration;
+import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class GlobalsPluginTest {
+
+    /**
+     * Verifies aggregating run errors and only attachments backed by report content.
+     */
+    @Description
+    @Test
+    void shouldAggregateGlobalsAndExcludeAttachmentsWithoutContent(@TempDir final Path temp) {
+        final GlobalError error = new GlobalError()
+                .setMessage("Run setup failed");
+        final GlobalAttachment available = new GlobalAttachment()
+                .setUid("available")
+                .setName("Run log")
+                .setSource("available.txt")
+                .setType("text/plain")
+                .setSize(12L);
+        final GlobalAttachment missing = new GlobalAttachment()
+                .setUid("missing")
+                .setName("Missing log")
+                .setSource("missing.txt")
+                .setType("text/plain");
+        final Attachment stored = new Attachment()
+                .setUid("available")
+                .setName("Run log")
+                .setSource("available.txt")
+                .setType("text/plain")
+                .setSize(12L);
+        final DefaultLaunchResults launch = new DefaultLaunchResults(
+                Set.of(),
+                Map.of(temp.resolve("run.log"), stored),
+                Map.of(),
+                List.of(error),
+                List.of(available, missing)
+        );
+        final Configuration configuration = ConfigurationBuilder.empty().build();
+        final ReportStorage storage = mock();
+
+        Allure.step(
+                "Aggregate run-level errors and attachments",
+                () -> new GlobalsPlugin().aggregate(configuration, List.of(launch), storage)
+        );
+
+        final ArgumentCaptor<Object> dataCaptor = ArgumentCaptor.captor();
+        verify(storage, times(1)).addDataJson(eq("widgets/globals.json"), dataCaptor.capture());
+        assertThat(dataCaptor.getValue()).isInstanceOf(GlobalsData.class);
+
+        final GlobalsData data = (GlobalsData) dataCaptor.getValue();
+        assertThat(data.getErrors()).containsExactly(error);
+        assertThat(data.getAttachments()).containsExactly(available);
+    }
+
+}

--- a/allure-generator/src/test/java/io/qameta/allure/testdata/TestData.java
+++ b/allure-generator/src/test/java/io/qameta/allure/testdata/TestData.java
@@ -173,6 +173,8 @@ public final class TestData {
             final List<TestResult> testResults = sortedResults(results.getAllResults());
             attachJson("launch-results.json", testResults);
             attachJson("launch-attachments.json", describeAttachments(results));
+            attachJson("launch-global-errors.json", results.getGlobalErrors());
+            attachJson("launch-global-attachments.json", results.getGlobalAttachments());
 
             results.getAttachments().entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())

--- a/allure-generator/src/test/resources/allure2/globals.json
+++ b/allure-generator/src/test/resources/allure2/globals.json
@@ -1,0 +1,20 @@
+{
+  "errors": [
+    {
+      "timestamp": 1724662800000,
+      "message": "Container DatabaseTests failed, tests inside it did not run",
+      "trace": "java.lang.IllegalStateException: database is unavailable\n\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
+      "actual": "database unavailable",
+      "expected": "database ready",
+      "environment": "qa"
+    }
+  ],
+  "attachments": [
+    {
+      "name": "Launch log",
+      "type": "text/plain",
+      "source": "launch.log",
+      "environment": "qa"
+    }
+  ]
+}

--- a/allure-generator/src/test/resources/allure2/globals.json
+++ b/allure-generator/src/test/resources/allure2/globals.json
@@ -11,6 +11,7 @@
   ],
   "attachments": [
     {
+      "timestamp": 1724662800500,
       "name": "Launch log",
       "type": "text/plain",
       "source": "launch.log",

--- a/allure-generator/src/test/resources/allure2/launch.log
+++ b/allure-generator/src/test/resources/allure2/launch.log
@@ -1,0 +1,2 @@
+Starting test infrastructure
+Database readiness check failed

--- a/allure-generator/tests/e2e/run.spec.mts
+++ b/allure-generator/tests/e2e/run.spec.mts
@@ -1,0 +1,124 @@
+import { expect, test, type Page } from "playwright/test";
+import { fixtures, REPORT_MODES } from "./support/fixtures.mts";
+import { openReport } from "./support/report.mts";
+import { previewContainerFor } from "./support/ui.mts";
+
+const runTabLink = (page: Page) => page.locator('.side-nav__link[data-tab="run"]');
+
+test.describe("Run errors and attachments", () => {
+  test("marks an otherwise green report unsuccessful without changing test statistics", async ({
+    page,
+  }) => {
+    await test.step("Open the overview with a passed test and a global error", async () => {
+      await openReport(page, {
+        fixture: fixtures.globalsGreen.name,
+        mode: REPORT_MODES.DIRECTORY,
+      });
+
+      await expect(page.locator(".run-status-banner__title")).toHaveText(
+        "Run completed with errors",
+      );
+      await expect(page.locator(".run-status-banner__description")).toContainText(
+        "All 1 reported tests passed",
+      );
+      await expect(page.locator(".summary-widget__stats .splash__title")).toHaveText("1");
+      await expect(runTabLink(page)).toHaveClass(/side-nav__link_error/);
+      await expect(runTabLink(page).locator(".side-nav__badge")).toHaveText("1");
+    });
+
+    await test.step("Review the run error and its attachment", async () => {
+      await page.getByRole("link", { name: "Review run details" }).click();
+      await expect(page).toHaveURL(/#run$/);
+      await expect(page.locator(".run-view__outcome-title")).toHaveText("Run failed");
+      await expect(page.locator(".run-view__error-message")).toHaveText(
+        fixtures.globalsGreen.error,
+      );
+      await expect(page.locator(".run-view")).not.toContainText("Environment: qa");
+      await expect(page.locator(".run-view__comparison")).toContainText("database ready");
+
+      const attachment = page.locator(".attachment-row", {
+        hasText: fixtures.globalsGreen.attachment,
+      });
+      await expect(attachment).toBeVisible();
+      await attachment.click();
+      await expect(
+        previewContainerFor(attachment).locator(".attachment-preview__text"),
+      ).toContainText(fixtures.globalsGreen.attachmentContent);
+    });
+  });
+
+  test("explains when a run failed before any tests were reported", async ({ page }) => {
+    await test.step("Open a fixture-only failure with zero test results", async () => {
+      await openReport(page, {
+        fixture: fixtures.globalsNoTests.name,
+        mode: REPORT_MODES.DIRECTORY,
+      });
+
+      await expect(page.locator(".run-status-banner__title")).toHaveText(
+        "Run failed before tests were reported",
+      );
+      await expect(page.locator(".summary-widget__stats .splash__title")).toHaveText("0");
+      await expect(runTabLink(page).locator(".side-nav__badge")).toHaveText("1");
+    });
+
+    await test.step("Show the unmodeled fixture error without a phantom test", async () => {
+      await runTabLink(page).click();
+      await expect(page.locator(".run-view__error-message")).toHaveText(
+        fixtures.globalsNoTests.error,
+      );
+      await expect(page.locator(".run-view__error")).toHaveCount(1);
+      await expect(page.locator(".run-view__attachments .attachment-row")).toHaveCount(0);
+    });
+  });
+
+  test("keeps attachment-only runs neutral and makes evidence available", async ({ page }) => {
+    await test.step("Open an attachment-only run", async () => {
+      await openReport(page, {
+        fixture: fixtures.globalsAttachments.name,
+        mode: REPORT_MODES.DIRECTORY,
+      });
+
+      await expect(page.locator(".run-status-banner")).toHaveCount(0);
+      await expect(runTabLink(page)).toBeVisible();
+      await expect(runTabLink(page)).not.toHaveClass(/side-nav__link_error/);
+      await expect(runTabLink(page).locator(".side-nav__badge")).toBeHidden();
+    });
+
+    await test.step("Open the global attachment from the neutral Run page", async () => {
+      await runTabLink(page).click();
+      await expect(page.locator(".run-view__outcome-title")).toHaveText("No run errors");
+      const attachment = page.locator(".attachment-row", {
+        hasText: fixtures.globalsAttachments.attachment,
+      });
+      await attachment.click();
+      await expect(
+        previewContainerFor(attachment).locator(".attachment-preview__text"),
+      ).toContainText(fixtures.globalsAttachments.attachmentContent);
+    });
+  });
+
+  test("loads global metadata and attachment content from a single-file report", async ({
+    page,
+  }) => {
+    await test.step("Open the embedded Run page", async () => {
+      await openReport(page, {
+        fixture: fixtures.globalsGreen.name,
+        mode: REPORT_MODES.SINGLE_FILE,
+        route: "run",
+      });
+      await expect(page.locator(".run-view__error-message")).toHaveText(
+        fixtures.globalsGreen.error,
+      );
+    });
+
+    await test.step("Preview the embedded run attachment", async () => {
+      const attachment = page.locator(".attachment-row", {
+        hasText: fixtures.globalsGreen.attachment,
+      });
+      await attachment.click();
+      await expect(
+        previewContainerFor(attachment).locator(".attachment-preview__text"),
+      ).toContainText(fixtures.globalsGreen.attachmentContent);
+    });
+  });
+});

--- a/allure-generator/tests/e2e/run.spec.mts
+++ b/allure-generator/tests/e2e/run.spec.mts
@@ -97,6 +97,29 @@ test.describe("Run errors and attachments", () => {
     });
   });
 
+  test("shows attachment timestamps and orders evidence by time then name", async ({ page }) => {
+    await openReport(page, {
+      fixture: fixtures.globalsAttachments.name,
+      mode: REPORT_MODES.DIRECTORY,
+      route: "run",
+    });
+
+    await expect(page.locator(".run-view__attachments .attachment-row__name")).toHaveText(
+      fixtures.globalsAttachments.orderedAttachments,
+    );
+    await expect(page.locator(".attachment-row__details")).toHaveCount(3);
+    await expect(
+      page.locator(".attachment-row", {
+        hasText: fixtures.globalsAttachments.attachment,
+      }).locator(".attachment-row__details"),
+    ).toContainText("2024");
+    await expect(
+      page.locator(".attachment-row", { hasText: "Alpha legacy log" }).locator(
+        ".attachment-row__details",
+      ),
+    ).toHaveCount(0);
+  });
+
   test("loads global metadata and attachment content from a single-file report", async ({
     page,
   }) => {

--- a/allure-generator/tests/e2e/support/fixtures.mts
+++ b/allure-generator/tests/e2e/support/fixtures.mts
@@ -149,4 +149,19 @@ export const fixtures = {
     longParameter:
       "frontend.pages.spreadsheets.quarterly.exports.with.a.parameter.value.that.is.long.enough.to.use.the.remaining.tree.row.space",
   },
+  globalsGreen: {
+    name: "globals-green",
+    error: "Global beforeAll fixture failed",
+    attachment: "Global launch log",
+    attachmentContent: "the database fixture failed before the remaining tests could start",
+  },
+  globalsNoTests: {
+    name: "globals-no-tests",
+    error: "Container DatabaseTests failed, tests inside it did not run",
+  },
+  globalsAttachments: {
+    name: "globals-attachments",
+    attachment: "Browser console log",
+    attachmentContent: "Browser console remained clean throughout the test run",
+  },
 } as const;

--- a/allure-generator/tests/e2e/support/fixtures.mts
+++ b/allure-generator/tests/e2e/support/fixtures.mts
@@ -163,5 +163,11 @@ export const fixtures = {
     name: "globals-attachments",
     attachment: "Browser console log",
     attachmentContent: "Browser console remained clean throughout the test run",
+    orderedAttachments: [
+      "Beta setup log",
+      "Zeta setup log",
+      "Browser console log",
+      "Alpha legacy log",
+    ],
   },
 } as const;

--- a/allure-generator/tests/fixtures/raw/globals-attachments/alpha-legacy.log
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/alpha-legacy.log
@@ -1,0 +1,1 @@
+Legacy run evidence did not report a timestamp.

--- a/allure-generator/tests/fixtures/raw/globals-attachments/beta-setup.log
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/beta-setup.log
@@ -1,0 +1,1 @@
+Beta setup completed at the same time as the zeta setup task.

--- a/allure-generator/tests/fixtures/raw/globals-attachments/browser-console.log
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/browser-console.log
@@ -1,0 +1,1 @@
+Browser console remained clean throughout the test run.

--- a/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-globals.json
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-globals.json
@@ -1,0 +1,11 @@
+{
+  "errors": [],
+  "attachments": [
+    {
+      "name": "Browser console log",
+      "type": "text/plain",
+      "source": "browser-console.log",
+      "environment": "staging"
+    }
+  ]
+}

--- a/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-globals.json
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-globals.json
@@ -2,10 +2,28 @@
   "errors": [],
   "attachments": [
     {
+      "timestamp": 1724662802000,
       "name": "Browser console log",
       "type": "text/plain",
       "source": "browser-console.log",
       "environment": "staging"
+    },
+    {
+      "timestamp": 1724662800000,
+      "name": "Zeta setup log",
+      "type": "text/plain",
+      "source": "zeta-setup.log"
+    },
+    {
+      "name": "Alpha legacy log",
+      "type": "text/plain",
+      "source": "alpha-legacy.log"
+    },
+    {
+      "timestamp": 1724662800000,
+      "name": "Beta setup log",
+      "type": "text/plain",
+      "source": "beta-setup.log"
     }
   ]
 }

--- a/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-result.json
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/globals-attachments-result.json
@@ -1,0 +1,20 @@
+{
+  "uuid": "globals-attachments-result",
+  "historyId": "globals-attachments-history",
+  "name": "reported test passes with run evidence",
+  "fullName": "io.qameta.allure.GlobalsTest.reportedTestPassesWithRunEvidence",
+  "status": "passed",
+  "stage": "finished",
+  "start": 1724662799000,
+  "stop": 1724662800000,
+  "steps": [],
+  "attachments": [],
+  "parameters": [],
+  "labels": [
+    {
+      "name": "suite",
+      "value": "Globals"
+    }
+  ],
+  "links": []
+}

--- a/allure-generator/tests/fixtures/raw/globals-attachments/zeta-setup.log
+++ b/allure-generator/tests/fixtures/raw/globals-attachments/zeta-setup.log
@@ -1,0 +1,1 @@
+Zeta setup completed before the browser session started.

--- a/allure-generator/tests/fixtures/raw/globals-green/global-run.log
+++ b/allure-generator/tests/fixtures/raw/globals-green/global-run.log
@@ -1,0 +1,1 @@
+Global launch log: the database fixture failed before the remaining tests could start.

--- a/allure-generator/tests/fixtures/raw/globals-green/globals-green-globals.json
+++ b/allure-generator/tests/fixtures/raw/globals-green/globals-green-globals.json
@@ -11,6 +11,7 @@
   ],
   "attachments": [
     {
+      "timestamp": 1724662800500,
       "name": "Global launch log",
       "type": "text/plain",
       "source": "global-run.log",

--- a/allure-generator/tests/fixtures/raw/globals-green/globals-green-globals.json
+++ b/allure-generator/tests/fixtures/raw/globals-green/globals-green-globals.json
@@ -1,0 +1,20 @@
+{
+  "errors": [
+    {
+      "timestamp": 1724662800000,
+      "message": "Global beforeAll fixture failed",
+      "trace": "java.lang.IllegalStateException: database is unavailable\n\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
+      "actual": "database unavailable",
+      "expected": "database ready",
+      "environment": "qa"
+    }
+  ],
+  "attachments": [
+    {
+      "name": "Global launch log",
+      "type": "text/plain",
+      "source": "global-run.log",
+      "environment": "qa"
+    }
+  ]
+}

--- a/allure-generator/tests/fixtures/raw/globals-green/globals-green-result.json
+++ b/allure-generator/tests/fixtures/raw/globals-green/globals-green-result.json
@@ -1,0 +1,20 @@
+{
+  "uuid": "globals-green-result",
+  "historyId": "globals-green-history",
+  "name": "reported test remains passed",
+  "fullName": "io.qameta.allure.GlobalsTest.reportedTestRemainsPassed",
+  "status": "passed",
+  "stage": "finished",
+  "start": 1724662799000,
+  "stop": 1724662800000,
+  "steps": [],
+  "attachments": [],
+  "parameters": [],
+  "labels": [
+    {
+      "name": "suite",
+      "value": "Globals"
+    }
+  ],
+  "links": []
+}

--- a/allure-generator/tests/fixtures/raw/globals-no-tests/globals-no-tests-globals.json
+++ b/allure-generator/tests/fixtures/raw/globals-no-tests/globals-no-tests-globals.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "timestamp": 1724662800000,
+      "message": "Container DatabaseTests failed, tests inside it did not run",
+      "trace": "java.lang.IllegalStateException: database is unavailable\n\tat example.DatabaseFixture.beforeAll(DatabaseFixture.java:42)",
+      "environment": "qa"
+    }
+  ],
+  "attachments": []
+}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/core/LaunchResults.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/core/LaunchResults.java
@@ -16,9 +16,13 @@
 package io.qameta.allure.core;
 
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.TestResult;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -56,6 +60,24 @@ public interface LaunchResults {
      * @return attachments.
      */
     Map<Path, Attachment> getAttachments();
+
+    /**
+     * Returns errors that belong to the entire test run.
+     *
+     * @return global errors.
+     */
+    default List<GlobalError> getGlobalErrors() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns attachments that belong to the entire test run.
+     *
+     * @return global attachments.
+     */
+    default List<GlobalAttachment> getGlobalAttachments() {
+        return Collections.emptyList();
+    }
 
     /**
      * Returns extra info by given name.

--- a/allure-plugin-api/src/main/java/io/qameta/allure/core/ResultsVisitor.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/core/ResultsVisitor.java
@@ -16,6 +16,8 @@
 package io.qameta.allure.core;
 
 import io.qameta.allure.entity.Attachment;
+import io.qameta.allure.entity.GlobalAttachment;
+import io.qameta.allure.entity.GlobalError;
 import io.qameta.allure.entity.TestResult;
 
 import java.nio.file.Path;
@@ -43,6 +45,25 @@ public interface ResultsVisitor {
      * @param result the result to process.
      */
     void visitTestResult(TestResult result);
+
+    /**
+     * Process an error that belongs to the entire test run.
+     *
+     * @param error the global error to process.
+     */
+    default void visitGlobalError(final GlobalError error) {
+        // Compatibility no-op for third-party visitors.
+    }
+
+    /**
+     * Process an attachment that belongs to the entire test run.
+     * The attachment content must also be registered with {@link #visitAttachmentFile(Path)}.
+     *
+     * @param attachment the global attachment to process.
+     */
+    default void visitGlobalAttachment(final GlobalAttachment attachment) {
+        // Compatibility no-op for third-party visitors.
+    }
 
     /**
      * Visit extra block. You can access this block using {@link LaunchResults#getExtra(String)}.

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalAttachment.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalAttachment.java
@@ -29,6 +29,7 @@ public class GlobalAttachment implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    protected Long timestamp;
     protected String uid;
     protected String name;
     protected String source;

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalAttachment.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalAttachment.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.entity;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+/**
+ * Describes an attachment that belongs to the entire test run rather than to a test result.
+ */
+@Data
+@Accessors(chain = true)
+public class GlobalAttachment implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected String uid;
+    protected String name;
+    protected String source;
+    protected String type;
+    protected Long size;
+
+}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalError.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/GlobalError.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.entity;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+/**
+ * Describes an error that belongs to the entire test run rather than to a test result.
+ */
+@Data
+@Accessors(chain = true)
+public class GlobalError implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected Long timestamp;
+    protected String message;
+    protected String trace;
+    protected String actual;
+    protected String expected;
+
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

This adds first-class run-level errors and attachments to Allure 2 reports. Integrations can report setup and container failures without creating fake test results, keeping test statistics accurate while clearly marking the overall run unsuccessful—even when every reported test passes or a fixture failure prevents tests from being reported.

Reports with run-level data now show a prominent warning on Overview and a contextual Run tab with error details, traces, expected and actual values, and attachment previews and downloads. The Run tab remains hidden when no global errors or attachments exist, preserving the navigation of existing reports.

<img width="1776" height="1106" alt="Screenshot 2026-08-26 at 20 20 24" src="https://github.com/user-attachments/assets/9edd0021-d4b2-498c-a2da-b677d8c71ab5" />

<img width="1777" height="1102" alt="Screenshot 2026-08-26 at 20 20 34" src="https://github.com/user-attachments/assets/32692417-d646-4848-beac-a072b09c867b" />

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2