### PR TITLE
Restore test history after upgrading to Allure 2.45.0

### DIFF
--- a/allure-generator/src/main/java/io/qameta/allure/allure1/Allure1Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure1/Allure1Plugin.java
@@ -50,12 +50,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PushbackReader;
+import java.math.BigInteger;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -108,6 +111,7 @@ public class Allure1Plugin implements Reader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Allure1Plugin.class);
     private static final String UNKNOWN = "unknown";
+    private static final String MD_5 = "md5";
     private static final String ISSUE_URL_PROPERTY = "allure.issues.tracker.pattern";
     private static final String TMS_LINK_PROPERTY = "allure.tests.management.pattern";
     private static final Comparator<Parameter> PARAMETER_COMPARATOR = comparing(Parameter::getName, nullsFirst(naturalOrder()))
@@ -202,6 +206,14 @@ public class Allure1Plugin implements Reader {
         final String name = firstNonNull(source.getTitle(), source.getName(), "unknown test case");
 
         final List<Parameter> parameters = getParameters(source);
+        final Optional<ru.yandex.qatools.allure.model.Label> historyId = source.getLabels().stream()
+                .filter(label -> "historyId".equals(label.getName()))
+                .findAny();
+        dest.setLegacyHistoryId(
+                historyId.isPresent()
+                        ? historyId.get().getValue()
+                        : getLegacyHistoryId(String.format("%s#%s", testClass, name), parameters)
+        );
         dest.setUid(randomUid.get());
         dest.setName(name);
         dest.setFullName(String.format("%s.%s", testClass, testMethod));
@@ -505,6 +517,27 @@ public class Allure1Plugin implements Reader {
                                 "firstNonNull method should have at least one non null parameter"
                         )
                 );
+    }
+
+    private static String getLegacyHistoryId(final String name, final List<Parameter> parameters) {
+        final MessageDigest digest = getMessageDigest();
+        digest.update(name.getBytes(UTF_8));
+        parameters.stream()
+                .sorted(PARAMETER_COMPARATOR)
+                .forEachOrdered(parameter -> {
+                    digest.update(Objects.toString(parameter.getName()).getBytes(UTF_8));
+                    digest.update(Objects.toString(parameter.getValue()).getBytes(UTF_8));
+                });
+        final byte[] bytes = digest.digest();
+        return new BigInteger(1, bytes).toString(16);
+    }
+
+    private static MessageDigest getMessageDigest() {
+        try {
+            return MessageDigest.getInstance(MD_5);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Could not find md5 hashing algorithm", e);
+        }
     }
 
     private Map<String, String> processEnvironment(final Path directory) {

--- a/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/allure2/Allure2Plugin.java
@@ -255,6 +255,7 @@ public class Allure2Plugin implements Reader {
         final io.qameta.allure.entity.TestResult dest = new io.qameta.allure.entity.TestResult()
                 .setTestCaseHash(getTestCaseHash(result))
                 .setParametersHash(getParametersHash(result))
+                .setLegacyHistoryId(result.getHistoryId())
                 .setUid(uidGenerator.get());
         dest.setFullName(result.getFullName());
         dest.setName(firstNonNull(result.getName(), result.getFullName(), "Unknown test"));

--- a/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
+++ b/allure-generator/src/main/java/io/qameta/allure/history/HistoryPlugin.java
@@ -149,7 +149,10 @@ public class HistoryPlugin extends CommonJsonAggregator2 implements Reader {
                                final ExecutorInfo info) {
         final HistoryData data = history.computeIfAbsent(
                 result.getRetryHash(),
-                id -> new HistoryData().setStatistic(new Statistic())
+                id -> Optional.ofNullable(result.getLegacyHistoryId())
+                        .map(history::get)
+                        .map(HistoryPlugin::copy)
+                        .orElseGet(() -> new HistoryData().setStatistic(new Statistic()))
         );
 
         data.getStatistic().update(result);

--- a/allure-generator/src/test/java/io/qameta/allure/allure1/Allure1PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure1/Allure1PluginTest.java
@@ -363,6 +363,13 @@ class Allure1PluginTest {
                                 "59143445e8de68070640560c106299fe.87749f11750f15b79e8b18a921eec986"
                         )
                 );
+        assertThat(testResults)
+                .extracting(TestResult::getLegacyHistoryId)
+                .as("Legacy history ids for parameterized tests must remain compatible")
+                .containsExactlyInAnyOrder(
+                        "56f15d234f8ad63b493afb25f7c26556",
+                        "e374f6eb3cf497543291506c8c20353"
+                );
     }
 
     /**
@@ -412,7 +419,7 @@ class Allure1PluginTest {
     }
 
     /**
-     * Verifies legacy Allure 1 history-id labels do not override generated retry hashes.
+     * Verifies legacy Allure 1 history-id labels are preserved without overriding generated retry hashes.
      */
     @Description
     @Test
@@ -423,16 +430,22 @@ class Allure1PluginTest {
 
         assertThat(results)
                 .filteredOn("name", "test1")
-                .extracting(TestResult::getRetryHash)
+                .extracting(TestResult::getRetryHash, TestResult::getLegacyHistoryId)
                 .containsExactly(
-                        "47c78c8a5a1548bc8e800a8f2e7caeb8.d41d8cd98f00b204e9800998ecf8427e"
+                        Tuple.tuple(
+                                "47c78c8a5a1548bc8e800a8f2e7caeb8.d41d8cd98f00b204e9800998ecf8427e",
+                                "something"
+                        )
                 );
 
         assertThat(results)
                 .filteredOn("name", "test2")
-                .extracting(TestResult::getRetryHash)
+                .extracting(TestResult::getRetryHash, TestResult::getLegacyHistoryId)
                 .containsExactly(
-                        "2b562de6055b47e72bac4c19bc9b7ec4.d41d8cd98f00b204e9800998ecf8427e"
+                        Tuple.tuple(
+                                "2b562de6055b47e72bac4c19bc9b7ec4.d41d8cd98f00b204e9800998ecf8427e",
+                                null
+                        )
                 );
     }
 

--- a/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/allure2/Allure2PluginTest.java
@@ -393,7 +393,7 @@ class Allure2PluginTest {
     }
 
     /**
-     * Verifies ignoring adapter-provided identity fields and calculating canonical hashes.
+     * Verifies calculating canonical hashes while preserving the adapter-provided history ID for fallback.
      */
     @Description
     @Test
@@ -406,13 +406,15 @@ class Allure2PluginTest {
                 .extracting(
                         TestResult::getTestCaseHash,
                         TestResult::getParametersHash,
-                        TestResult::getRetryHash
+                        TestResult::getRetryHash,
+                        TestResult::getLegacyHistoryId
                 )
                 .containsExactly(
                         tuple(
                                 "fa121e5badc3c93651d3921a7898a04c",
                                 "9030faa44fb9da8aeaee27f28c29a4f9",
-                                "fa121e5badc3c93651d3921a7898a04c.9030faa44fb9da8aeaee27f28c29a4f9"
+                                "fa121e5badc3c93651d3921a7898a04c.9030faa44fb9da8aeaee27f28c29a4f9",
+                                "adapter-provided-history-id"
                         )
                 );
     }

--- a/allure-generator/src/test/java/io/qameta/allure/history/HistoryPluginTest.java
+++ b/allure-generator/src/test/java/io/qameta/allure/history/HistoryPluginTest.java
@@ -161,6 +161,37 @@ class HistoryPluginTest {
         assertThat(data.get(retryHash(testCaseHash2)).getItems()).hasSize(2);
     }
 
+    /**
+     * Verifies history falls back to the adapter-provided key when the canonical retry hash is absent.
+     */
+    @Description
+    @Test
+    void shouldFallbackToLegacyHistory() {
+        final String testCaseHash = UUID.randomUUID().toString();
+        final String legacyHistoryId = UUID.randomUUID().toString();
+        final Map<String, Object> extra = new HashMap<>();
+        final Map<String, HistoryData> historyDataMap = new HashMap<>();
+        historyDataMap.put(
+                legacyHistoryId,
+                new HistoryData()
+                        .setItems(singletonList(createHistoryItem(PASSED, 1, 2)))
+        );
+        extra.put(HISTORY_BLOCK_NAME, historyDataMap);
+        final TestResult testResult = createTestResult(FAILED, testCaseHash, 100, 101)
+                .setLegacyHistoryId(legacyHistoryId);
+
+        final Map<String, HistoryData> data = getHistoryData(extra, testResult);
+
+        assertThat(data).containsKey(retryHash(testCaseHash));
+        assertThat(data.get(retryHash(testCaseHash)).getItems())
+                .extracting(HistoryItem::getStatus)
+                .containsExactly(FAILED, PASSED);
+        assertThat(testResult.<HistoryData>getExtraBlock(HISTORY_BLOCK_NAME).getItems())
+                .extracting(HistoryItem::getStatus)
+                .containsExactly(PASSED);
+        assertThat(testResult.isNewFailed()).isTrue();
+    }
+
     private Map<String, HistoryData> copyHistoryData(Map<String, HistoryData> historyDataMap) {
         return historyDataMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> new HistoryData().setItems(e.getValue().getItems())));

--- a/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/entity/TestResult.java
@@ -50,6 +50,8 @@ public class TestResult implements Serializable, Nameable, Parameterizable, Stat
     protected String testCaseHash;
     @JsonIgnore
     protected String parametersHash;
+    @JsonIgnore
+    protected transient String legacyHistoryId;
     protected String testId;
     protected Time time = new Time();
     protected String description;

--- a/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
+++ b/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java
@@ -261,6 +261,7 @@ public class JunitXmlPlugin implements Reader {
         result.setUid(context.getValue().get());
         result.setName(isNull(name) ? "Unknown test case" : name);
         if (nonNull(className) && nonNull(name)) {
+            result.setLegacyHistoryId(String.format("%s:%s#%s", info.getName(), className, name));
             result.setFullName(className + "." + name);
         }
         result.setTime(getTime(info.getTimestamp(), testCaseElement, parsedFile));

--- a/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
+++ b/plugins/junit-xml-plugin/src/test/java/io/qameta/allure/junitxml/JunitXmlPluginTest.java
@@ -229,7 +229,7 @@ class JunitXmlPluginTest {
 
     /**
      * Verifies repeated JUnit results are modeled as retries.
-     * The test checks visible and hidden retry flags, retry hashes, and status details.
+     * The test checks visible and hidden retry flags, current and legacy history keys, and status details.
      */
     @Description
     @Test
@@ -247,6 +247,9 @@ class JunitXmlPluginTest {
                         Tuple.tuple("searchTest", Status.BROKEN, true, "fbad9a3df2386edf402f5fceb9614f19.d41d8cd98f00b204e9800998ecf8427e"),
                         Tuple.tuple("searchTest", Status.FAILED, true, "fbad9a3df2386edf402f5fceb9614f19.d41d8cd98f00b204e9800998ecf8427e")
                 );
+        assertThat(results)
+                .extracting(TestResult::getLegacyHistoryId)
+                .containsOnly("my.company.tests.SearchTest:my.company.tests.SearchTest#searchTest");
 
         assertThat(results)
                 .extracting(TestResult::getStatusMessage, TestResult::getStatusTrace)

--- a/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
+++ b/plugins/trx-plugin/src/main/java/io/qameta/allure/trx/TrxPlugin.java
@@ -209,6 +209,7 @@ public class TrxPlugin implements Reader {
             result.setParameters(unitTest.getParameters());
             result.setDescription(unitTest.getDescription());
             result.setFullName(fullName);
+            result.setLegacyHistoryId(fullName);
             result.addLabelIfNotExists(SUITE, className);
             result.addLabelIfNotExists(TEST_CLASS, className);
             result.addLabelIfNotExists(PACKAGE, className);

--- a/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
+++ b/plugins/trx-plugin/src/test/java/io/qameta/allure/trx/TrxPluginTest.java
@@ -74,7 +74,7 @@ class TrxPluginTest {
 
     /**
      * Verifies a TRX file is converted into Allure test results.
-     * The test checks parsed data, generated identity hashes, and result format labels.
+     * The test checks parsed data, current and legacy identity keys, and result format labels.
      */
     @Description
     @Test
@@ -107,6 +107,9 @@ class TrxPluginTest {
             assertThat(result.getRetryHash())
                     .as("retry hash for %s", result.getName())
                     .isEqualTo(result.getTestCaseHash() + "." + result.getParametersHash());
+            assertThat(result.getLegacyHistoryId())
+                    .as("legacy history id for %s", result.getName())
+                    .isEqualTo(result.getFullName());
         });
 
     }

--- a/plugins/xunit-xml-plugin/src/main/java/io/qameta/allure/xunitxml/XunitXmlPlugin.java
+++ b/plugins/xunit-xml-plugin/src/main/java/io/qameta/allure/xunitxml/XunitXmlPlugin.java
@@ -138,6 +138,7 @@ public class XunitXmlPlugin implements Reader {
         result.setTime(getTime(testElement));
 
         fullName.ifPresent(result::setFullName);
+        fullName.ifPresent(result::setLegacyHistoryId);
         getStatusMessage(testElement).ifPresent(result::setStatusMessage);
         getStatusTrace(testElement).ifPresent(result::setStatusTrace);
         getParameters(testElement).ifPresent(result::setParameters);

--- a/plugins/xunit-xml-plugin/src/test/java/io/qameta/allure/xunitxml/XunitXmlPluginTest.java
+++ b/plugins/xunit-xml-plugin/src/test/java/io/qameta/allure/xunitxml/XunitXmlPluginTest.java
@@ -72,7 +72,7 @@ class XunitXmlPluginTest {
 
     /**
      * Verifies an xUnit XML test case is converted into an Allure result.
-     * The test checks parsed name, identity hashes, and passed status.
+     * The test checks parsed name, current and legacy identity keys, and passed status.
      */
     @Description
     @Test
@@ -91,6 +91,7 @@ class XunitXmlPluginTest {
                         TestResult::getTestCaseHash,
                         TestResult::getParametersHash,
                         TestResult::getRetryHash,
+                        TestResult::getLegacyHistoryId,
                         TestResult::getStatus
                 )
                 .containsExactlyInAnyOrder(
@@ -99,6 +100,7 @@ class XunitXmlPluginTest {
                                 "41252492d10e496cdec9d61c5eed7b51",
                                 "d41d8cd98f00b204e9800998ecf8427e",
                                 "41252492d10e496cdec9d61c5eed7b51.d41d8cd98f00b204e9800998ecf8427e",
+                                "Some test",
                                 Status.PASSED
                         )
                 );


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Preserve existing test history when reports switch to the new retry identifiers. Reports generated from Allure 1, Allure 2, JUnit XML, TRX, and xUnit XML can reuse history created by earlier Allure versions instead of showing an empty History tab after an upgrade.

The first newly generated report migrates the previous history to the current identifiers, allowing subsequent reports to continue normally.

fixes #3470

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2